### PR TITLE
Adds multiple tables ability for embedding

### DIFF
--- a/dev/payload-types.ts
+++ b/dev/payload-types.ts
@@ -68,8 +68,7 @@ export interface Config {
   blocks: {};
   collections: {
     posts: Post;
-    media: Media;
-    embeddings: Embedding;
+    default: Default;
     users: User;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -79,8 +78,7 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     posts: PostsSelect<false> | PostsSelect<true>;
-    media: MediaSelect<false> | MediaSelect<true>;
-    embeddings: EmbeddingsSelect<false> | EmbeddingsSelect<true>;
+    default: DefaultSelect<false> | DefaultSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -151,30 +149,12 @@ export interface Post {
   createdAt: string;
 }
 /**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "media".
- */
-export interface Media {
-  id: number;
-  updatedAt: string;
-  createdAt: string;
-  url?: string | null;
-  thumbnailURL?: string | null;
-  filename?: string | null;
-  mimeType?: string | null;
-  filesize?: number | null;
-  width?: number | null;
-  height?: number | null;
-  focalX?: number | null;
-  focalY?: number | null;
-}
-/**
  * Vector embeddings for search and similarity queries. Created by the payloadcms-vectorize plugin. Embeddings cannot be added or modified, only deleted, through the admin panel. No other restrictions enforced.
  *
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "embeddings".
+ * via the `definition` "default".
  */
-export interface Embedding {
+export interface Default {
   id: number;
   /**
    * The collection that this embedding belongs to
@@ -324,12 +304,8 @@ export interface PayloadLockedDocument {
         value: number | Post;
       } | null)
     | ({
-        relationTo: 'media';
-        value: number | Media;
-      } | null)
-    | ({
-        relationTo: 'embeddings';
-        value: number | Embedding;
+        relationTo: 'default';
+        value: number | Default;
       } | null)
     | ({
         relationTo: 'users';
@@ -393,26 +369,9 @@ export interface PostsSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "media_select".
+ * via the `definition` "default_select".
  */
-export interface MediaSelect<T extends boolean = true> {
-  updatedAt?: T;
-  createdAt?: T;
-  url?: T;
-  thumbnailURL?: T;
-  filename?: T;
-  mimeType?: T;
-  filesize?: T;
-  width?: T;
-  height?: T;
-  focalX?: T;
-  focalY?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "embeddings_select".
- */
-export interface EmbeddingsSelect<T extends boolean = true> {
+export interface DefaultSelect<T extends boolean = true> {
   sourceCollection?: T;
   docId?: T;
   fieldPath?: T;

--- a/dev/specs/constants.ts
+++ b/dev/specs/constants.ts
@@ -46,15 +46,26 @@ export const getInitialMarkdownContent = async (
   })
 }
 
-export const integration = createVectorizeIntegration({ dims: DIMS, ivfflatLists: 1 })
+export const embeddingsCollection = 'default'
+
+export const integration = createVectorizeIntegration({
+  default: {
+    dims: DIMS,
+    ivfflatLists: 1,
+  },
+})
 export const vectorizeCronJob = { cron: '*/10 * * * * *', limit: 5, queue: 'default' }
 export const plugin = integration.payloadcmsVectorize
 
 export const dummyPluginOptions = {
-  collections: {},
-  embedDocs: async (texts: string[]) => texts.map(() => [0, 0, 0, 0, 0, 0, 0, 0]),
-  embedQuery: async (text: string) => [0, 0, 0, 0, 0, 0, 0, 0],
-  embeddingVersion: 'test',
+  knowledgePools: {
+    default: {
+      collections: {},
+      embedDocs: async (texts: string[]) => texts.map(() => [0, 0, 0, 0, 0, 0, 0, 0]),
+      embedQuery: async (text: string) => [0, 0, 0, 0, 0, 0, 0, 0],
+      embeddingVersion: 'test',
+    },
+  },
   queueNameOrCronJob: vectorizeCronJob,
 }
 

--- a/dev/specs/e2e.spec.ts
+++ b/dev/specs/e2e.spec.ts
@@ -22,6 +22,7 @@ test('querying the endpoint should return the title when queried', async ({ requ
   const response = await request.post('/api/vector-search', {
     data: {
       query: title,
+      knowledgePool: 'default',
     },
   })
   expect(response.ok()).toBe(true)

--- a/dev/specs/multipools.spec.ts
+++ b/dev/specs/multipools.spec.ts
@@ -1,0 +1,99 @@
+import type { Payload, SanitizedConfig } from 'payload'
+
+import { buildConfig, getPayload } from 'payload'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { createVectorizeIntegration } from 'payloadcms-vectorize'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { createTestDb } from './utils.js'
+import type { PostgresPayload } from '../../src/types.js'
+
+const DIMS_POOL1 = 8
+const DIMS_POOL2 = 16
+
+describe('Multiple knowledge pools', () => {
+  let config: SanitizedConfig
+  let payload: Payload
+  const dbName = 'multipools_test'
+
+  beforeAll(async () => {
+    await createTestDb({ dbName })
+
+    const multiPoolIntegration = createVectorizeIntegration({
+      pool1: {
+        dims: DIMS_POOL1,
+        ivfflatLists: 1,
+      },
+      pool2: {
+        dims: DIMS_POOL2,
+        ivfflatLists: 2,
+      },
+    })
+
+    const multiPoolPluginOptions = {
+      knowledgePools: {
+        pool1: {
+          collections: {},
+          embedDocs: async (texts: string[]) => texts.map(() => new Array(DIMS_POOL1).fill(0)),
+          embedQuery: async () => new Array(DIMS_POOL1).fill(0),
+          embeddingVersion: 'test-pool1',
+        },
+        pool2: {
+          collections: {},
+          embedDocs: async (texts: string[]) => texts.map(() => new Array(DIMS_POOL2).fill(0)),
+          embedQuery: async () => new Array(DIMS_POOL2).fill(0),
+          embeddingVersion: 'test-pool2',
+        },
+      },
+    }
+
+    config = await buildConfig({
+      secret: 'test-secret',
+      collections: [],
+      editor: lexicalEditor(),
+      db: postgresAdapter({
+        extensions: ['vector'],
+        afterSchemaInit: [multiPoolIntegration.afterSchemaInitHook],
+        pool: {
+          connectionString: `postgresql://postgres:password@localhost:5433/${dbName}`,
+        },
+      }),
+      plugins: [multiPoolIntegration.payloadcmsVectorize(multiPoolPluginOptions)],
+    })
+
+    payload = await getPayload({ config })
+  })
+
+  test('creates two embeddings collections with vector columns', async () => {
+    const collections = payload.collections
+    expect(collections).toHaveProperty('pool1')
+    expect(collections).toHaveProperty('pool2')
+
+    const db = (payload as PostgresPayload).db
+    const tablesRes = await db.pool?.query(
+      `
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN ('pool1', 'pool2')
+      `,
+    )
+
+    expect(tablesRes?.rowCount).toBe(2)
+
+    const columnsRes = await db.pool?.query(
+      `
+        SELECT table_name, column_name, udt_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name IN ('pool1', 'pool2')
+          AND column_name = 'embedding'
+      `,
+    )
+
+    expect(columnsRes?.rowCount).toBe(2)
+    columnsRes?.rows.forEach((row: { udt_name: string }) => {
+      expect(row.udt_name).toBe('vector')
+    })
+  })
+})

--- a/dev/specs/queueName.spec.ts
+++ b/dev/specs/queueName.spec.ts
@@ -35,17 +35,21 @@ describe('Queue tests', () => {
       plugins: [
         plugin({
           queueName: expectedQueueName,
-          collections: {
-            posts: {
-              fields: {
-                title: { chunker: chunkText },
-                content: { chunker: chunkRichText },
+          knowledgePools: {
+            default: {
+              collections: {
+                posts: {
+                  fields: {
+                    title: { chunker: chunkText },
+                    content: { chunker: chunkRichText },
+                  },
+                },
               },
+              embedDocs: async () => [[0, 0, 0, 0, 0, 0, 0, 0]],
+              embedQuery: async () => [0, 0, 0, 0, 0, 0, 0, 0],
+              embeddingVersion: 'test',
             },
           },
-          embedDocs: async () => [[0, 0, 0, 0, 0, 0, 0, 0]],
-          embedQuery: async () => [0, 0, 0, 0, 0, 0, 0, 0],
-          embeddingVersion: 'test',
         }),
       ],
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/collections/embeddings.ts
+++ b/src/collections/embeddings.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
+import type { KnowledgePoolName } from '../types.js'
 
-export const createEmbeddingsCollection = (slug: string = 'embeddings'): CollectionConfig => ({
+export const createEmbeddingsCollection = (slug: KnowledgePoolName): CollectionConfig => ({
   slug,
   admin: {
     description:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { CollectionSlug, Payload, Config } from 'payload'
+import type { CollectionSlug, Payload } from 'payload'
 import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
 
 export type EmbedDocsFn = (texts: string[]) => Promise<number[][] | Float32Array[]>
@@ -20,17 +20,21 @@ export type CollectionVectorizeOption = {
   fields: Record<string, FieldVectorizeOption>
 }
 
+/** Knowledge pool name identifier */
+export type KnowledgePoolName = string
+
+/** Static configuration for a knowledge pool */
 /** Note current limitation: needs a migration in order to change after initial creation */
-export type StaticIntegrationConfig = {
-  /** Name of the embeddings collection created by the plugin */
-  embeddingsSlugOverride?: string
+export type KnowledgePoolStaticConfig = {
   /** Vector dimensions for pgvector column */
   dims: number
   /** IVFFLAT lists parameter used when creating the index */
   ivfflatLists: number
 }
 
-export type PayloadcmsVectorizeConfig = {
+/** Dynamic configuration for a knowledge pool */
+/** Does not need a migration in order to change after initial creation */
+export type KnowledgePoolDynamicConfig = {
   /** Collections and fields to vectorize */
   collections: Partial<Record<CollectionSlug, CollectionVectorizeOption>>
   /** Embedding function for document provided by the user */
@@ -39,6 +43,11 @@ export type PayloadcmsVectorizeConfig = {
   embedQuery: EmbedQueryFn
   /** Version string to track embedding model/version - stored in each embedding document */
   embeddingVersion: string
+}
+
+export type PayloadcmsVectorizeConfig = {
+  /** Knowledge pools and their dynamic configurations */
+  knowledgePools: Record<KnowledgePoolName, KnowledgePoolDynamicConfig>
   /** Task queue name.
    * Default is payloadcms default queue (undefined)
    * You must setup the job in your payload config
@@ -82,6 +91,7 @@ export type VectorizeTaskArgs = {
   pluginOptions: PayloadcmsVectorizeConfig & { embeddingsCollectionSlug?: string }
   doc: Record<string, any>
   collection: string
+  knowledgePool: KnowledgePoolName
   fieldsConfig: Record<string, FieldVectorizeOption>
 }
 
@@ -101,9 +111,12 @@ export interface VectorSearchResponse {
 }
 
 export interface VectorSearchQuery {
+  /** The knowledge pool to search in */
+  knowledgePool: KnowledgePoolName
+  /** The search query string */
+  query: string
   // TODO(techiejd): Expand on query API
   // add support for particular collections, fields, etc.
-  query: string
 }
 
 export type JobContext = {
@@ -112,5 +125,3 @@ export type JobContext = {
   req: any
   tasks: any
 }
-
-export const DEFAULT_EMBEDDINGS_COLLECTION = 'embeddings'


### PR DESCRIPTION
## Summary

Refactors the plugin to support multiple knowledge pools (RAG tables) instead of a single embeddings table. Each knowledge pool can have independent technical requirements (vector dimensions, IVFFLAT index parameters, and embedding functions).

## Changes

### Core Functionality
- **Multiple Knowledge Pools**: Users can now define multiple knowledge pools, each with its own configuration
- **Static vs Dynamic Config Split**: Knowledge pool configuration is now split into:
  - **Static config** (`dims`, `ivfflatLists`): Schema-related, requires database migrations
  - **Dynamic config** (`collections`, `embedDocs`, `embedQuery`, `embeddingVersion`): Runtime configuration, no migrations needed
- **Independent Configurations**: Each knowledge pool can have different vector dimensions, index parameters, and embedding functions
- **Collection-to-Pool Mapping**: Collections can appear in multiple knowledge pools simultaneously

### API Changes
- **Configuration Structure**: Changed from `{collections: {...}}` to `{knowledgePools: {poolName: {...}}}`
- **Vector Search Endpoint**: Now requires `knowledgePool` parameter in request body
- **Embeddings Collection Naming**: Collection names now match knowledge pool names (removed `embeddingsSlugOverride`)

### Technical Improvements
- **Unified Task System**: Refactored to use a single task handler that can process jobs for any knowledge pool
- **Improved Hook Logic**: `afterChange` and `afterDelete` hooks now update all relevant knowledge pools
- **Better Type Safety**: Added `KnowledgePoolName`, `KnowledgePoolStaticConfig`, and `KnowledgePoolDynamicConfig` types

### Removed Features
- `embeddingsSlugOverride` option (no longer needed)
- `DEFAULT_EMBEDDINGS_COLLECTION` constant (knowledge pool name is used directly)

## Breaking Changes

⚠️ **This is a breaking change** - Version upgraded from `v0.1.0` to `v0.2.0`

- Configuration structure has changed (see Migration Guide in README)
- Vector search endpoint now requires `knowledgePool` parameter
- Embeddings collection naming convention changed

## Testing

- ✅ All existing integration tests updated and passing
- ✅ New multi-pool test suite added (`multipools.spec.ts`)
- ✅ Database schema validation for multiple pools
- ✅ Vector search endpoint tests updated

## Documentation

- Updated README with new configuration examples
- Added migration guide from v0.1.0 to v0.2.0
- Documented static vs dynamic configuration separation