### PR TITLE
Adds better type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.3.1 - 2025-01-XX
+
+### Changed
+
+- Improved type safety: `PayloadcmsVectorizeConfig` is now generic and enforces that `knowledgePools` keys match `staticConfigs` keys exactly.
+
 ## 0.3.0 - 2025-11-19
 
 ### Added

--- a/dev/specs/vectorSearch.spec.ts
+++ b/dev/specs/vectorSearch.spec.ts
@@ -14,7 +14,7 @@ import {
 import { createTestDb, waitForVectorizationJobs } from './utils.js'
 import { postgresAdapter } from '@payloadcms/db-postgres'
 import { chunkRichText, chunkText } from 'helpers/chunkers.js'
-import { vectorSearch } from '../../src/endpoints/vectorSearch.js'
+import { createVectorSearchHandler } from '../../src/endpoints/vectorSearch.js'
 import type { KnowledgePoolDynamicConfig } from 'payloadcms-vectorize'
 
 const embedFn = makeDummyEmbedQuery(DIMS)
@@ -35,7 +35,7 @@ async function performVectorSearch(
       embeddingVersion: testEmbeddingVersion,
     },
   }
-  const searchHandler = vectorSearch(knowledgePools)
+  const searchHandler = createVectorSearchHandler(knowledgePools)
 
   // Create a mock request object
   const mockRequest = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/endpoints/vectorSearch.ts
+++ b/src/endpoints/vectorSearch.ts
@@ -26,15 +26,20 @@ import type {
 } from 'payloadcms-vectorize'
 import { getEmbeddingsTable } from '../drizzle/tables.js'
 
-export const vectorSearch = (
-  knowledgePools: Record<KnowledgePoolName, KnowledgePoolDynamicConfig>,
+export const createVectorSearchHandler = <TPoolNames extends KnowledgePoolName>(
+  knowledgePools: Record<TPoolNames, KnowledgePoolDynamicConfig>,
 ) => {
   const _vectorSearch: PayloadHandler = async (req) => {
     if (!req || !req.json) {
       return Response.json({ error: 'Request is required' }, { status: 400 })
     }
     try {
-      const { query, knowledgePool, where, limit = 10 }: VectorSearchQuery = await req.json()
+      const {
+        query,
+        knowledgePool,
+        where,
+        limit = 10,
+      }: VectorSearchQuery<TPoolNames> = await req.json()
       if (!query || typeof query !== 'string') {
         return Response.json({ error: 'Query is required and must be a string' }, { status: 400 })
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,9 +40,9 @@ export type KnowledgePoolDynamicConfig = {
   embeddingVersion: string
 }
 
-export type PayloadcmsVectorizeConfig = {
+export type PayloadcmsVectorizeConfig<TPoolNames extends KnowledgePoolName = KnowledgePoolName> = {
   /** Knowledge pools and their dynamic configurations */
-  knowledgePools: Record<KnowledgePoolName, KnowledgePoolDynamicConfig>
+  knowledgePools: Record<TPoolNames, KnowledgePoolDynamicConfig>
   /** Task queue name.
    * Default is payloadcms default queue (undefined)
    * You must setup the job in your payload config
@@ -105,9 +105,9 @@ export interface VectorSearchResponse {
   results: VectorSearchResult[]
 }
 
-export interface VectorSearchQuery {
+export interface VectorSearchQuery<TPoolNames extends KnowledgePoolName = KnowledgePoolName> {
   /** The knowledge pool to search in */
-  knowledgePool: KnowledgePoolName
+  knowledgePool: TPoolNames
   /** The search query string */
   query: string
   /** Optional Payload where clause to filter results. Can rely on embeddings collection fields or extension fields. */


### PR DESCRIPTION
- Improved type safety: `PayloadcmsVectorizeConfig` is now generic and enforces that `knowledgePools` keys match `staticConfigs` keys exactly (no more, no less).
- `VectorSearchQuery` is now generic to provide better type safety for the `knowledgePool` parameter.
- Renamed `vectorSearch` to `createVectorSearchHandler` for clarity.
- Removed unnecessary type assertions by using `for...in` loops which preserve key types from `Record` types.