### PR TITLE
Returns extensionFields in vector search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.3.1 - 2025-01-XX
+## 0.3.2 - 2025-11-26
+
+### Fixed
+
+- Vector search endpoint now returns `extensionFields` in search results with correct types (numbers as numbers, strings as strings, etc.). Previously, extension fields were stored but not included in search results.
+
+## 0.3.1 - 2025-11-19
 
 ### Changed
 

--- a/dev/specs/extensionFieldsVectorSearch.spec.ts
+++ b/dev/specs/extensionFieldsVectorSearch.spec.ts
@@ -1,0 +1,157 @@
+import { getPayload } from 'payload'
+import { describe, expect, test } from 'vitest'
+import { makeDummyEmbedDocs, makeDummyEmbedQuery, testEmbeddingVersion } from 'helpers/embed.js'
+import { buildDummyConfig, DIMS, integration, plugin } from './constants.js'
+import { createTestDb, waitForVectorizationJobs } from './utils.js'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { chunkRichText, chunkText } from 'helpers/chunkers.js'
+import { createVectorSearchHandler } from '../../src/endpoints/vectorSearch.js'
+import type { KnowledgePoolDynamicConfig } from 'payloadcms-vectorize'
+
+describe('extensionFields', () => {
+  test('returns extensionFields in search results with correct types', async () => {
+    // Create a new payload instance with extensionFields
+    await createTestDb({ dbName: 'endpoint_test_extension' })
+    const defaultKnowledgePool: KnowledgePoolDynamicConfig = {
+      collections: {
+        posts: {
+          toKnowledgePool: async (doc, payload) => {
+            const chunks: Array<{ chunk: string; category?: string; priorityLevel?: number }> = []
+            // Process title
+            if (doc.title) {
+              const titleChunks = chunkText(doc.title)
+              chunks.push(
+                ...titleChunks.map((chunk) => ({
+                  chunk,
+                  category: doc.category || 'general',
+                  priorityLevel: doc.priorityLevel || 0,
+                })),
+              )
+            }
+            // Process content
+            if (doc.content) {
+              const contentChunks = await chunkRichText(doc.content, payload)
+              chunks.push(
+                ...contentChunks.map((chunk) => ({
+                  chunk,
+                  category: doc.category || 'general',
+                  priorityLevel: doc.priorityLevel || 0,
+                })),
+              )
+            }
+            return chunks
+          },
+          extensionFields: [
+            {
+              name: 'category',
+              type: 'text',
+              admin: {
+                description: 'Category for filtering embeddings',
+              },
+            },
+            {
+              name: 'priorityLevel',
+              type: 'number',
+              admin: {
+                description: 'Priority level for the embedding',
+              },
+            },
+          ],
+        },
+      },
+      embedDocs: makeDummyEmbedDocs(DIMS),
+      embedQuery: makeDummyEmbedQuery(DIMS),
+      embeddingVersion: testEmbeddingVersion,
+    } as const
+    const configWithExtensions = await buildDummyConfig({
+      jobs: {
+        tasks: [],
+        autoRun: [
+          {
+            cron: '*/5 * * * * *', // Run every 5 seconds
+            limit: 10,
+          },
+        ],
+      },
+      collections: [
+        {
+          slug: 'posts',
+          fields: [
+            { name: 'title', type: 'text' },
+            { name: 'content', type: 'richText' },
+            { name: 'category', type: 'text' },
+            { name: 'priorityLevel', type: 'number' },
+          ],
+        },
+      ],
+      db: postgresAdapter({
+        extensions: ['vector'],
+        afterSchemaInit: [integration.afterSchemaInitHook],
+        pool: {
+          connectionString: 'postgresql://postgres:password@localhost:5433/endpoint_test_extension',
+        },
+      }),
+      plugins: [
+        plugin({
+          knowledgePools: {
+            default: defaultKnowledgePool,
+          },
+        }),
+      ],
+    })
+    const payloadWithExtensions = await getPayload({ config: configWithExtensions })
+
+    // Create a post with extension field values
+    const testQuery = 'Extension fields test content'
+    const post = await payloadWithExtensions.create({
+      collection: 'posts',
+      data: {
+        title: testQuery,
+        content: null,
+        category: 'tech',
+        priorityLevel: 42,
+      } as unknown as any,
+    })
+
+    // Wait for vectorization jobs to complete
+    await waitForVectorizationJobs(payloadWithExtensions)
+
+    // Perform vector search
+    const knowledgePools: Record<string, KnowledgePoolDynamicConfig> = {
+      default: defaultKnowledgePool,
+    }
+    const searchHandler = createVectorSearchHandler(knowledgePools)
+    const mockRequest = {
+      json: async () => ({
+        query: testQuery,
+        knowledgePool: 'default',
+      }),
+      payload: payloadWithExtensions,
+    } as any
+    const response = await searchHandler(mockRequest)
+    const json = await response.json()
+
+    // Verify results contain extensionFields
+    expect(json).toHaveProperty('results')
+    expect(Array.isArray(json.results)).toBe(true)
+    expect(json.results.length).toBeGreaterThan(0)
+
+    // Find a result that matches our post
+    const matchingResult = json.results.find(
+      (r: any) => r.docId === String(post.id) && r.chunkText === testQuery,
+    )
+    expect(matchingResult).toBeDefined()
+
+    console.log(matchingResult)
+
+    // Verify extensionFields are present
+    expect(matchingResult).toHaveProperty('category')
+    expect(matchingResult).toHaveProperty('priorityLevel')
+
+    // Verify types are correct
+    expect(typeof matchingResult.category).toBe('string')
+    expect(matchingResult.category).toBe('tech')
+    expect(typeof matchingResult.priorityLevel).toBe('number')
+    expect(matchingResult.priorityLevel).toBe(42)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/drizzle/tables.ts
+++ b/src/drizzle/tables.ts
@@ -1,6 +1,8 @@
 import type { KnowledgePoolName } from '../types.js'
+import type { Table } from '@payloadcms/db-postgres/drizzle'
 
-type DrizzleTable = Record<string, any>
+// Extend Table to allow dynamic column access (for extension fields)
+type DrizzleTable = Table & Record<string, any>
 
 const embeddingsTables = new Map<KnowledgePoolName, DrizzleTable>()
 


### PR DESCRIPTION

### Summary

This PR fixes the vector search endpoint so that it correctly returns any `extensionFields` stored on embeddings, and ensures numeric fields are returned as numbers.

### Changes

- **Vector search endpoint**
  - Updated `performCosineSearch` to:
    - Use the embeddings collection config from `payload.collections[poolName].config`
    - Dynamically build the Drizzle `select` shape from that config (reserved fields + all extension fields)
    - Use the registered embeddings `table` from the new typed `DrizzleTable` registry
  - Simplified `mapRowsToResults` to:
    - Normalize `id` and `docId` to `string`
    - Normalize `similarity` and `chunkIndex` to `number`
    - Coerce any embeddings collection fields declared as `type: 'number'` (including extensionFields) to `number`
    - Leave all other fields (e.g. text extensionFields) as-is

- **Drizzle table registry**
  - Changed the embeddings table registry to use `DrizzleTable = Table & Record<string, any>` to:
    - Keep Drizzle’s `Table` type so `.from(table)` is correctly typed
    - Allow dynamic indexing for extension field columns (e.g. `table[extensionFieldName]`)

- **Tests**
  - Added `dev/specs/extensionFieldsVectorSearch.spec.ts`:
    - Builds a config with an embeddings pool that declares `extensionFields` (`category: text`, `priorityLevel: number`)
    - Indexes documents with those values via `toKnowledgePool`
    - Asserts that vector search results include:
      - `category` as a `string`
      - `priorityLevel` (and the document’s own `priority` field when used) as a `number`
  - Kept existing `extensionFields` integration tests (schema + storage) untouched

- **Versioning & docs**
  - Bumped version to **0.3.2**
  - Updated `CHANGELOG.md` to document:
    - Vector search now returns `extensionFields` in results
    - Numeric fields (including extensionFields) are surfaced as numbers, not strings

### Rationale

- Previously, extensionFields were written into the embeddings collection but dropped at query time because the Drizzle `select` only projected the reserved columns.
- This change uses the embeddings collection schema as the single source of truth for which columns to select and how to type them, so any extensionFields you add to a knowledge pool will automatically:
  - Be stored on embeddings (existing behavior)
  - Be returned by vector search
  - Have the correct JS type (especially for `number` fields) in the API response.