### PR TITLE
Move extensionFields from collection-level to knowledge-pool-level (0.4.0)...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.0 - 2025-11-26
+
+### Breaking
+
+- **`extensionFields` moved from collection-level to knowledge-pool-level.** Previously, `extensionFields` was defined per collection inside `CollectionVectorizeOption`. Now it is defined once per knowledge pool in `KnowledgePoolDynamicConfig`. This eliminates potential field conflicts when multiple collections contribute to the same pool.
+
+### Migration
+
+**Before (≤0.3.x)**
+
+```ts
+payloadcmsVectorize({
+  knowledgePools: {
+    main: {
+      collections: {
+        posts: {
+          toKnowledgePool: postsToKnowledgePool,
+          extensionFields: [{ name: 'category', type: 'text' }],
+        },
+      },
+      embedDocs,
+      embedQuery,
+      embeddingVersion: 'v1.0.0',
+    },
+  },
+})
+```
+
+**After (0.4.0+)**
+
+```ts
+payloadcmsVectorize({
+  knowledgePools: {
+    main: {
+      collections: {
+        posts: {
+          toKnowledgePool: postsToKnowledgePool,
+        },
+      },
+      extensionFields: [{ name: 'category', type: 'text' }],
+      embedDocs,
+      embedQuery,
+      embeddingVersion: 'v1.0.0',
+    },
+  },
+})
+```
+
 ## 0.3.2 - 2025-11-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ export default buildConfig({
           collections: {
             posts: {
               toKnowledgePool: postsToKnowledgePool,
-              extensionFields: [
-                { name: 'category', type: 'text' },
-                { name: 'priority', type: 'number' },
-              ],
             },
           },
+          extensionFields: [
+            { name: 'category', type: 'text' },
+            { name: 'priority', type: 'number' },
+          ],
           embedDocs,
           embedQuery,
           embeddingVersion: 'v1.0.0',
@@ -164,12 +164,12 @@ const { results } = await response.json()
 
 ### Plugin Options
 
-| Option              | Type                                         | Required | Description                              |
-| ------------------- | -------------------------------------------- | -------- | ---------------------------------------- |
-| `knowledgePools`    | `Record<KnowledgePool, KnowledgePoolConfig>` | ✅       | Knowledge pools and their configurations |
-| `queueName`         | `string`                                     | ❌       | Custom queue name for background jobs    |
-| `endpointOverrides` | `object`                                     | ❌       | Customize the search endpoint            |
-| `disabled`          | `boolean`                                    | ❌       | Disable plugin while keeping schema      |
+| Option              | Type                                                | Required | Description                              |
+| ------------------- | --------------------------------------------------- | -------- | ---------------------------------------- |
+| `knowledgePools`    | `Record<KnowledgePool, KnowledgePoolDynamicConfig>` | ✅       | Knowledge pools and their configurations |
+| `queueName`         | `string`                                            | ❌       | Custom queue name for background jobs    |
+| `endpointOverrides` | `object`                                            | ❌       | Customize the search endpoint            |
+| `disabled`          | `boolean`                                           | ❌       | Disable plugin while keeping schema      |
 
 ### Knowledge Pool Config
 
@@ -184,15 +184,15 @@ The embeddings collection name will be the same as the knowledge pool name.
 
 **2. Dynamic Config** (passed to `payloadcmsVectorize`):
 
-- `collections`: `Record<string, CollectionVectorizeOption>` - Collections and their chunking/extension configs
+- `collections`: `Record<string, CollectionVectorizeOption>` - Collections and their chunking configs
 - `embedDocs`: `EmbedDocsFn` - Function to embed multiple documents
 - `embedQuery`: `EmbedQueryFn` - Function to embed search queries
 - `embeddingVersion`: `string` - Version string for tracking model changes
+- `extensionFields?`: `Field[]` - Optional fields to extend the embeddings collection schema
 
 #### CollectionVectorizeOption
 
 - `toKnowledgePool (doc, payload)` – return an array of `{ chunk, ...extensionFieldValues }`. Each object becomes one embedding row and the index in the array determines `chunkIndex`.
-- `extensionFields?` – standard Payload `Field[]` merged onto the embeddings collection. These values can be written from `toKnowledgePool` output and queried later (including via the `where` parameter).
 
 Reserved column names: `sourceCollection`, `docId`, `chunkIndex`, `chunkText`, `embeddingVersion`. Avoid reusing them in `extensionFields`.
 

--- a/dev/specs/extensionFields.spec.ts
+++ b/dev/specs/extensionFields.spec.ts
@@ -76,24 +76,24 @@ describe('Extension fields integration tests', () => {
                     }
                     return chunks
                   },
-                  extensionFields: [
-                    {
-                      name: 'category',
-                      type: 'text',
-                      admin: {
-                        description: 'Category for filtering embeddings',
-                      },
-                    },
-                    {
-                      name: 'priority',
-                      type: 'number',
-                      admin: {
-                        description: 'Priority level for the embedding',
-                      },
-                    },
-                  ],
                 },
               },
+              extensionFields: [
+                {
+                  name: 'category',
+                  type: 'text',
+                  admin: {
+                    description: 'Category for filtering embeddings',
+                  },
+                },
+                {
+                  name: 'priority',
+                  type: 'number',
+                  admin: {
+                    description: 'Priority level for the embedding',
+                  },
+                },
+              ],
               embedDocs: makeDummyEmbedDocs(DIMS),
               embedQuery: makeDummyEmbedQuery(DIMS),
               embeddingVersion: testEmbeddingVersion,

--- a/dev/specs/extensionFieldsVectorSearch.spec.ts
+++ b/dev/specs/extensionFieldsVectorSearch.spec.ts
@@ -41,24 +41,24 @@ describe('extensionFields', () => {
             }
             return chunks
           },
-          extensionFields: [
-            {
-              name: 'category',
-              type: 'text',
-              admin: {
-                description: 'Category for filtering embeddings',
-              },
-            },
-            {
-              name: 'priorityLevel',
-              type: 'number',
-              admin: {
-                description: 'Priority level for the embedding',
-              },
-            },
-          ],
         },
       },
+      extensionFields: [
+        {
+          name: 'category',
+          type: 'text',
+          admin: {
+            description: 'Category for filtering embeddings',
+          },
+        },
+        {
+          name: 'priorityLevel',
+          type: 'number',
+          admin: {
+            description: 'Priority level for the embedding',
+          },
+        },
+      ],
       embedDocs: makeDummyEmbedDocs(DIMS),
       embedQuery: makeDummyEmbedQuery(DIMS),
       embeddingVersion: testEmbeddingVersion,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,16 +151,12 @@ export const createVectorizeIntegration = <TPoolNames extends KnowledgePoolName>
       // Process each knowledge pool
       for (const poolName in pluginOptions.knowledgePools) {
         const dynamicConfig = pluginOptions.knowledgePools[poolName]
-        // Collect all extensionFields from all collections in this pool
-        const allExtensionFields: any[] = []
-        for (const collectionConfig of Object.values(dynamicConfig.collections)) {
-          if (collectionConfig?.extensionFields) {
-            allExtensionFields.push(...collectionConfig.extensionFields)
-          }
-        }
 
         // Add the embeddings collection for this knowledge pool with extensionFields
-        const embeddingsCollection = createEmbeddingsCollection(poolName, allExtensionFields)
+        const embeddingsCollection = createEmbeddingsCollection(
+          poolName,
+          dynamicConfig.extensionFields,
+        )
         if (!config.collections.find((c) => c.slug === poolName)) {
           config.collections.push(embeddingsCollection)
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,6 @@ export type ToKnowledgePoolFn = (
 export type CollectionVectorizeOption = {
   /** Function that converts a document to an array of chunks with optional extension field values */
   toKnowledgePool: ToKnowledgePoolFn
-  /** Optional fields to extend the embeddings collection schema */
-  extensionFields?: Field[]
 }
 
 /** Knowledge pool name identifier */
@@ -38,6 +36,8 @@ export type KnowledgePoolDynamicConfig = {
   embedQuery: EmbedQueryFn
   /** Version string to track embedding model/version - stored in each embedding document */
   embeddingVersion: string
+  /** Optional fields to extend the knowledge pool collection schema */
+  extensionFields?: Field[]
 }
 
 export type PayloadcmsVectorizeConfig<TPoolNames extends KnowledgePoolName = KnowledgePoolName> = {


### PR DESCRIPTION
... which is where it should've been from the start because it adds columns to the table.

### PR Title

Move `extensionFields` from collection-level to knowledge-pool-level (0.4.0)

### Summary

- **Breaking change**: `extensionFields` is now defined per knowledge pool (`KnowledgePoolDynamicConfig`) instead of per collection (`CollectionVectorizeOption`).
- **Reasoning**: A knowledge pool is a single embeddings table shared across collections, so its schema (including `extensionFields`) should be defined once at the pool level to avoid conflicts and duplication.

### Changes

- **Types**
  - Removed `extensionFields?: Field[]` from `CollectionVectorizeOption`.
  - Added `extensionFields?: Field[]` to `KnowledgePoolDynamicConfig`, updating the JSDoc to clarify that it extends the knowledge pool’s embeddings collection schema.

- **Core logic**
  - Simplified `src/index.ts` to stop merging `extensionFields` from each collection in a pool.
  - Now directly passes `dynamicConfig.extensionFields` into `createEmbeddingsCollection(poolName, dynamicConfig.extensionFields)`.

- **Tests**
  - Updated `dev/specs/extensionFields.spec.ts` and `dev/specs/extensionFieldsVectorSearch.spec.ts` to:
    - Remove collection-level `extensionFields`.
    - Define `extensionFields` on the knowledge pool and keep behavior expectations the same (schema + stored values + search results).

- **Docs**
  - Updated `README.md`:
    - Quick start example now shows pool-level `extensionFields`.
    - Dynamic config section documents `extensionFields` on `KnowledgePoolDynamicConfig`.
    - `CollectionVectorizeOption` docs no longer mention `extensionFields`.
    - Fixed `knowledgePools` type to reference `KnowledgePoolDynamicConfig` instead of `KnowledgePoolConfig`.

- **Versioning & changelog**
  - Bumped package version from `0.3.2` to `0.4.0`.
  - Added a `0.4.0` section to `CHANGELOG.md` describing the breaking change and providing before/after migration snippets.

### Migration Notes

- **Before (≤0.3.x)** – `extensionFields` on each collection:

```ts
payloadcmsVectorize({
  knowledgePools: {
    main: {
      collections: {
        posts: {
          toKnowledgePool: postsToKnowledgePool,
          extensionFields: [{ name: 'category', type: 'text' }],
        },
      },
      embedDocs,
      embedQuery,
      embeddingVersion: 'v1.0.0',
    },
  },
})
```

- **After (0.4.0+)** – `extensionFields` on the knowledge pool:

```ts
payloadcmsVectorize({
  knowledgePools: {
    main: {
      collections: {
        posts: {
          toKnowledgePool: postsToKnowledgePool,
        },
      },
      extensionFields: [{ name: 'category', type: 'text' }],
      embedDocs,
      embedQuery,
      embeddingVersion: 'v1.0.0',
    },
  },
})
```