### PR TITLE
Adds better error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.4.2 - 2025-01-XX
+## 0.4.3 - 2025-01-02
+
+- Added runtime validation for `toKnowledgePool` entries (requires `chunk` string).
+- Documented how to requeue failed jobs by clearing `hasError` and `completedAt`.
+
+## 0.4.2 - 2025-01-01
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -219,9 +219,15 @@ const postsToKnowledgePool: ToKnowledgePoolFn = async (doc, payload) => {
 
 Because you control the output, you can mix different field types, discard empty values, or inject any metadata that aligns with your `extensionFields`.
 
+## Validation & retries
+
+- Each entry returned by `toKnowledgePool` must be an object with a required `chunk` string.
+- If any entry is malformed, the vectorize job fails with `hasError = true` and an error message listing invalid indices.
+- To retry after fixing your `toKnowledgePool` logic, clear `hasError` and `completedAt` (and set `processing` to `false` if needed) on the failed `payload-jobs` row. The queue runner will pick it up on the next interval.
+
 ## PostgreSQL Custom Schema Support
 
-The plugin reads the `schemaName` configuration from your Postgres adapter within the Payload config.  
+The plugin reads the `schemaName` configuration from your Postgres adapter within the Payload config.
 
 When you configure a custom schema via `postgresAdapter({ schemaName: 'custom' })`, all plugin SQL queries (for vector columns, indexes, and embeddings) are qualified with that schema name. This is useful for multi-tenant setups or when content tables live in a dedicated schema.
 

--- a/dev/specs/failedValidation.spec.ts
+++ b/dev/specs/failedValidation.spec.ts
@@ -1,0 +1,98 @@
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { buildConfig } from 'payload'
+import { getPayload } from 'payload'
+import { describe, expect, test } from 'vitest'
+
+import { createVectorizeIntegration } from '../../src/index.js'
+import { waitForVectorizationJobs } from './utils.js'
+
+const DIMS = 8
+
+const embedDocs = async (texts: string[]) => texts.map(() => Array(DIMS).fill(0))
+const embedQuery = async (_text: string) => Array(DIMS).fill(0)
+
+const { afterSchemaInitHook, payloadcmsVectorize } = createVectorizeIntegration({
+  default: {
+    dims: DIMS,
+    ivfflatLists: 1,
+  },
+})
+
+const buildMalformedConfig = async () =>
+  buildConfig({
+    jobs: {
+      tasks: [],
+      autoRun: [
+        {
+          cron: '*/5 * * * * *', // Run every 5 seconds
+          limit: 10,
+        },
+      ],
+    },
+    collections: [
+      {
+        slug: 'posts',
+        fields: [{ name: 'title', type: 'text' }],
+      },
+    ],
+    db: postgresAdapter({
+      extensions: ['vector'],
+      afterSchemaInit: [afterSchemaInitHook],
+      pool: {
+        connectionString:
+          process.env.DATABASE_URI || 'postgresql://postgres:password@localhost:5433/payload_test',
+      },
+    }),
+    plugins: [
+      payloadcmsVectorize({
+        knowledgePools: {
+          default: {
+            collections: {
+              posts: {
+                // Malformed: second entry missing required "chunk" string
+                toKnowledgePool: async () => [{ chunk: 'ok chunk' }, { bad: 'oops' } as any],
+              },
+            },
+            embedDocs,
+            embedQuery,
+            embeddingVersion: 'malformed-test',
+          },
+        },
+      }),
+    ],
+    secret: 'failed-validation-secret',
+  })
+
+describe('Validation failures mark jobs as errored', () => {
+  test('malformed chunk entry fails the vectorize job', async () => {
+    const config = await buildMalformedConfig()
+    const payload = await getPayload({ config, cron: true })
+
+    await payload.create({
+      collection: 'posts',
+      data: { title: 'bad chunks' },
+    })
+
+    // Wait for the queued job to finish (success or failure)
+    await waitForVectorizationJobs(payload, 15000)
+
+    // Then assert failure
+    const res = await payload.find({
+      collection: 'payload-jobs',
+      where: {
+        and: [{ taskSlug: { equals: 'payloadcms-vectorize:vectorize' } }],
+      },
+      limit: 1,
+      sort: '-createdAt',
+    })
+    const failedJob = (res as any)?.docs?.[0]
+    expect(failedJob.hasError).toBe(true)
+    const errMsg = failedJob.error.message
+    expect(errMsg).toMatch(/chunk/i)
+    expect(errMsg).toMatch(/Invalid indices: 1/)
+
+    // Ensure no embeddings were created (all-or-nothing validation)
+    const embeddingsCount = await payload.count({ collection: 'default' })
+    expect(embeddingsCount.totalDocs).toBe(0)
+  })
+})

--- a/dev/specs/int.spec.ts
+++ b/dev/specs/int.spec.ts
@@ -17,7 +17,6 @@ import { PostgresPayload } from '../../src/types.js'
 import { editorConfigFactory, getEnabledNodes } from '@payloadcms/richtext-lexical'
 import { DIMS, embeddingsCollection, getInitialMarkdownContent } from './constants.js'
 import { waitForVectorizationJobs } from './utils.js'
-import { Post } from 'payload-types.js'
 
 const embedFn = makeDummyEmbedDocs(DIMS)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Add runtime validation for `toKnowledgePool` outputs

### Summary

This PR adds runtime validation to ensure that `toKnowledgePool` callback outputs are properly formatted before processing. If any entry is malformed (missing the required `chunk` string property), the vectorize job now fails explicitly with `hasError = true` and a clear error message, rather than silently skipping invalid entries.

### Changes

#### Runtime Validation (`src/tasks/vectorize.ts`)
- Added validation to check that each entry returned by `toKnowledgePool` is an object with a required `chunk` string property
- If validation fails, the job throws an error with a message listing all invalid indices (e.g., `"Invalid indices: 1, 3"`)
- Ensures atomic behavior: if any entry is invalid, the entire job fails and no embeddings are created

#### Testing (`dev/specs/failedValidation.spec.ts`)
- Created new test file to verify validation failure behavior
- Tests that malformed entries (missing `chunk` property) cause the job to fail with `hasError = true`
- Verifies atomic behavior by testing multiple chunks where one is valid and another is invalid
- Confirms that no embeddings are created when validation fails

#### Documentation (`README.md`)
- Added "Validation & retries" section explaining:
  - Required format for `toKnowledgePool` entries
  - How validation failures are handled
  - How to requeue failed jobs by clearing `hasError` and `completedAt` fields in the `payload-jobs` collection

#### Version Bump (`package.json`)
- Upgraded version from `0.4.2` to `0.4.3`

### Benefits

1. **Early Error Detection**: Developers are immediately notified when their `toKnowledgePool` function returns malformed data, rather than silently skipping entries
2. **Clear Error Messages**: Error messages include the specific indices of invalid entries, making debugging easier
3. **Atomic Operations**: Ensures data consistency by preventing partial embeddings when validation fails
4. **Better Developer Experience**: Follows industry standards for validation and error handling

### Migration Notes

No breaking changes. Existing valid `toKnowledgePool` implementations will continue to work without modification. If you have implementations that return entries without a `chunk` property, they will now fail explicitly instead of being silently skipped.

### Testing

Run the new validation test:
pnpm test:int dev/specs/failedValidation.spec.tsAll existing tests should continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds input validation to prevent malformed chunks from being embedded and surfaces clear errors for easier debugging.
> 
> - Enforces that `toKnowledgePool` returns an array of objects each with a `chunk` string; invalid entries throw with indices in `src/tasks/vectorize.ts`
> - New test `dev/specs/failedValidation.spec.ts` verifies job failure (`hasError = true`), error message contents, and atomic no-op on failure
> - Docs: README gains **Validation & retries** section with steps to requeue failed jobs; CHANGELOG updated
> - Version bump to `0.4.3`; minor cleanup in `dev/specs/int.spec.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef63616b6192fbc1c6eb2bb7160f6532dd88d67d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->