### PR TITLE
fixes nonSnakeCase bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.4 - 2025-01-08
+
+- Fixes bug where you can't have collections that are not snake_case.
+- Should work as long as you follow any convention that can be parsed by to-snake-case's toSnakeCase.
+
 ## 0.4.3 - 2025-01-02
 
 - Added runtime validation for `toKnowledgePool` entries (requires `chunk` string).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/tasks/vectorize.ts
+++ b/src/tasks/vectorize.ts
@@ -6,6 +6,7 @@ import {
   KnowledgePoolDynamicConfig,
   ToKnowledgePoolFn,
 } from '../types.js'
+import toSnakeCase from 'to-snake-case'
 
 type VectorizeTaskInput = {
   doc: Record<string, any>
@@ -159,7 +160,9 @@ async function runVectorizeTask(args: {
       const literal = `[${Array.from(vector).join(',')}]`
       const postgresPayload = payload as PostgresPayload
       const schemaName = postgresPayload.db.schemaName || 'public'
-      const sql = `UPDATE "${schemaName}"."${poolName}" SET embedding = $1 WHERE id = $2` as string
+      // Drizzle converts camelCase collection slugs to snake_case table names
+      const sql =
+        `UPDATE "${schemaName}"."${toSnakeCase(poolName)}" SET embedding = $1 WHERE id = $2` as string
       try {
         await runSQL(sql, [literal, id])
       } catch (e) {


### PR DESCRIPTION
Fixes case where the knowledge pool collection does not follow snake_case convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures embeddings tables are resolved/updated using snake_case mappings so knowledge pool names that aren’t snake_case work correctly.
> 
> - Use `toSnakeCase` when resolving tables in `afterSchemaInitHook` and when issuing raw SQL updates in `vectorize` task (`src/index.ts`, `src/tasks/vectorize.ts`)
> - Add integration tests covering non-snake-case pool names and initialization (`dev/specs/vectorSearch.spec.ts`)
> - Bump version to `0.4.4` and update `CHANGELOG.md`; add `to-snake-case` dependency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f924c18cf3556243c5c4cfa5c64d7aec96c83c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->