### PR TITLE
Adds local api for vectorized payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.5 - 2025-01-09
+
+### Added
+
+- **Local API**: Added `payload.search()` and `payload.queueEmbed()` methods directly on the Payload instance for programmatic vector search without HTTP requests
+- `payload.search(params)` - Perform vector search programmatically with the same parameters as the HTTP endpoint
+- `payload.queueEmbed(params)` - Manually queue vectorization jobs for documents (by ID or with document object)
+- `isVectorizedPayload(payload)` - Type guard to check if a Payload instance has vectorize extensions
+
+### Example
+
+```typescript
+import { isVectorizedPayload, type VectorizedPayload } from 'payloadcms-vectorize'
+
+const payload = await getPayload({ config, cron: true })
+
+if (isVectorizedPayload(payload)) {
+  // Search programmatically
+  const results = await payload.search({
+    query: 'search query',
+    knowledgePool: 'main',
+    limit: 10,
+  })
+
+  // Queue embedding manually
+  await payload.queueEmbed({
+    collection: 'posts',
+    docId: 'post-id',
+  })
+}
+```
+
 ## 0.4.4 - 2025-01-08
 
 - Fixes bug where you can't have collections that are not snake_case.

--- a/dev/specs/extensionFieldsVectorSearch.spec.ts
+++ b/dev/specs/extensionFieldsVectorSearch.spec.ts
@@ -5,7 +5,7 @@ import { buildDummyConfig, DIMS, integration, plugin } from './constants.js'
 import { createTestDb, waitForVectorizationJobs } from './utils.js'
 import { postgresAdapter } from '@payloadcms/db-postgres'
 import { chunkRichText, chunkText } from 'helpers/chunkers.js'
-import { createVectorSearchHandler } from '../../src/endpoints/vectorSearch.js'
+import { createVectorSearchHandlers } from '../../src/endpoints/vectorSearch.js'
 import type { KnowledgePoolDynamicConfig } from 'payloadcms-vectorize'
 
 describe('extensionFields', () => {
@@ -120,7 +120,7 @@ describe('extensionFields', () => {
     const knowledgePools: Record<string, KnowledgePoolDynamicConfig> = {
       default: defaultKnowledgePool,
     }
-    const searchHandler = createVectorSearchHandler(knowledgePools)
+    const searchHandler = createVectorSearchHandlers(knowledgePools).requestHandler
     const mockRequest = {
       json: async () => ({
         query: testQuery,

--- a/dev/specs/helpers/vectorSearchExpectations.ts
+++ b/dev/specs/helpers/vectorSearchExpectations.ts
@@ -1,0 +1,99 @@
+import { expect } from 'vitest'
+import type { VectorSearchResult } from '../../../src/types.js'
+
+/**
+ * Shared test expectations for vector search results
+ * Can be used by both endpoint tests and direct method tests
+ */
+export function expectVectorSearchResults(results: VectorSearchResult[]) {
+  expect(Array.isArray(results)).toBe(true)
+  expect(results.length).toBeGreaterThan(0)
+}
+
+export function expectVectorSearchResultShape(result: VectorSearchResult) {
+  expect(result).toHaveProperty('id')
+  expect(result).toHaveProperty('similarity')
+  expect(result).toHaveProperty('sourceCollection')
+  expect(result).toHaveProperty('docId')
+  expect(result).toHaveProperty('chunkIndex')
+  expect(result).toHaveProperty('chunkText')
+  expect(result).toHaveProperty('embeddingVersion')
+}
+
+export function expectResultsOrderedBySimilarity(results: VectorSearchResult[]) {
+  expect(results.length).toBeGreaterThan(1)
+
+  for (let i = 0; i < results.length - 1; i++) {
+    expect(results[i].similarity).toBeGreaterThanOrEqual(results[i + 1].similarity)
+  }
+}
+
+export function expectResultsRespectLimit(results: VectorSearchResult[], limit: number) {
+  expect(results.length).toBeLessThanOrEqual(limit)
+}
+
+export function expectResultsRespectWhere(
+  results: VectorSearchResult[],
+  predicate: (result: VectorSearchResult) => boolean,
+) {
+  expect(results.length).toBeGreaterThan(0)
+  for (const result of results) {
+    expect(predicate(result)).toBe(true)
+  }
+}
+
+export function expectResultsContainTitle(
+  results: VectorSearchResult[],
+  title: string,
+  postId: string,
+  embeddingVersion: string,
+) {
+  expect(results).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        sourceCollection: 'posts',
+        docId: postId,
+        chunkIndex: 0,
+        chunkText: title,
+        embeddingVersion,
+      }),
+    ]),
+  )
+}
+
+/**
+ * Run all common search result expectations
+ */
+export function expectValidVectorSearchResults(
+  results: VectorSearchResult[],
+  options?: {
+    minResults?: number
+    checkShape?: boolean
+    checkOrdering?: boolean
+    expectedTitle?: { title: string; postId: string; embeddingVersion: string }
+    wherePredicate?: (result: VectorSearchResult) => boolean
+  },
+) {
+  expectVectorSearchResults(results)
+
+  if (options?.checkShape && results.length > 0) {
+    expectVectorSearchResultShape(results[0])
+  }
+
+  if (options?.checkOrdering && results.length > 1) {
+    expectResultsOrderedBySimilarity(results)
+  }
+
+  if (options?.expectedTitle) {
+    expectResultsContainTitle(
+      results,
+      options.expectedTitle.title,
+      options.expectedTitle.postId,
+      options.expectedTitle.embeddingVersion,
+    )
+  }
+
+  if (options?.wherePredicate) {
+    expectResultsRespectWhere(results, options.wherePredicate)
+  }
+}

--- a/dev/specs/schemaName.spec.ts
+++ b/dev/specs/schemaName.spec.ts
@@ -10,7 +10,7 @@ import type { PostgresPayload } from '../../src/types.js'
 
 import { buildDummyConfig, DIMS, integration, plugin } from './constants.js'
 import { createTestDb, waitForVectorizationJobs } from './utils.js'
-import { createVectorSearchHandler } from '../../src/endpoints/vectorSearch.js'
+import { createVectorSearchHandlers } from '../../src/endpoints/vectorSearch.js'
 import type { KnowledgePoolDynamicConfig } from 'payloadcms-vectorize'
 const CUSTOM_SCHEMA = 'custom'
 
@@ -173,7 +173,7 @@ describe('Custom schemaName support', () => {
         embeddingVersion: testEmbeddingVersion,
       },
     }
-    const searchHandler = createVectorSearchHandler(knowledgePools)
+    const searchHandler = createVectorSearchHandlers(knowledgePools).requestHandler
 
     const mockRequest = {
       json: async () => ({

--- a/dev/specs/vectorizedPayload.spec.ts
+++ b/dev/specs/vectorizedPayload.spec.ts
@@ -1,0 +1,239 @@
+import type { Payload } from 'payload'
+
+import { getPayload } from 'payload'
+import { beforeAll, describe, expect, test } from 'vitest'
+import { isVectorizedPayload, VectorizedPayload } from '../../src/types.js'
+import { buildDummyConfig, DIMS, getInitialMarkdownContent } from './constants.js'
+import { createTestDb, waitForVectorizationJobs } from './utils.js'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { makeDummyEmbedDocs, makeDummyEmbedQuery, testEmbeddingVersion } from 'helpers/embed.js'
+import { chunkRichText, chunkText } from 'helpers/chunkers.js'
+import { createVectorizeIntegration } from 'payloadcms-vectorize'
+import { type SerializedEditorState } from '@payloadcms/richtext-lexical/lexical'
+import {
+  expectValidVectorSearchResults,
+  expectResultsOrderedBySimilarity,
+  expectResultsRespectLimit,
+  expectResultsRespectWhere,
+  expectResultsContainTitle,
+} from './helpers/vectorSearchExpectations.js'
+
+const integration = createVectorizeIntegration({
+  default: {
+    dims: DIMS,
+    ivfflatLists: 1,
+  },
+})
+const plugin = integration.payloadcmsVectorize
+
+describe('VectorizedPayload', () => {
+  let payload: Payload
+  let markdownContent: SerializedEditorState
+  const titleAndQuery = 'VectorizedPayload Test Title'
+
+  beforeAll(async () => {
+    await createTestDb({ dbName: 'vectorized_payload_test' })
+    const config = await buildDummyConfig({
+      jobs: {
+        tasks: [],
+        autoRun: [
+          {
+            cron: '*/5 * * * * *',
+            limit: 10,
+          },
+        ],
+      },
+      collections: [
+        {
+          slug: 'posts',
+          fields: [
+            { name: 'title', type: 'text' },
+            { name: 'content', type: 'richText' },
+          ],
+        },
+      ],
+      db: postgresAdapter({
+        extensions: ['vector'],
+        afterSchemaInit: [integration.afterSchemaInitHook],
+        pool: {
+          connectionString: 'postgresql://postgres:password@localhost:5433/vectorized_payload_test',
+        },
+      }),
+      plugins: [
+        plugin({
+          knowledgePools: {
+            default: {
+              collections: {
+                posts: {
+                  toKnowledgePool: async (doc, payload) => {
+                    const chunks: Array<{ chunk: string }> = []
+                    if (doc.title) {
+                      const titleChunks = chunkText(doc.title)
+                      chunks.push(...titleChunks.map((chunk) => ({ chunk })))
+                    }
+                    if (doc.content) {
+                      const contentChunks = await chunkRichText(doc.content, payload)
+                      chunks.push(...contentChunks.map((chunk) => ({ chunk })))
+                    }
+                    return chunks
+                  },
+                },
+              },
+              embedDocs: makeDummyEmbedDocs(DIMS),
+              embedQuery: makeDummyEmbedQuery(DIMS),
+              embeddingVersion: testEmbeddingVersion,
+            },
+          },
+        }),
+      ],
+    })
+    payload = await getPayload({ config, cron: true })
+    markdownContent = await getInitialMarkdownContent(config)
+  })
+
+  describe('isVectorizedPayload type guard', () => {
+    test('returns true for a payload instance with vectorize extensions', () => {
+      expect(isVectorizedPayload(payload)).toBe(true)
+    })
+
+    test('returns false for a plain object without search method', () => {
+      const plainObj = { queueEmbed: () => Promise.resolve() } as unknown as Payload
+      expect(isVectorizedPayload(plainObj)).toBe(false)
+    })
+
+    test('returns false for a plain object without queueEmbed method', () => {
+      const plainObj = { search: () => Promise.resolve([]) } as unknown as Payload
+      expect(isVectorizedPayload(plainObj)).toBe(false)
+    })
+
+    test('returns false for an empty object', () => {
+      const emptyObj = {} as unknown as Payload
+      expect(isVectorizedPayload(emptyObj)).toBe(false)
+    })
+  })
+
+  describe('search method', () => {
+    let postId: string
+
+    beforeAll(async () => {
+      const post = await payload.create({
+        collection: 'posts',
+        data: {
+          title: titleAndQuery,
+          content: markdownContent as unknown as any,
+        },
+      })
+      postId = String(post.id)
+
+      await waitForVectorizationJobs(payload)
+    })
+
+    test('payload has search method', () => {
+      expect(typeof (payload as VectorizedPayload).search).toBe('function')
+    })
+
+    test('search returns an array of VectorSearchResult', async () => {
+      const vectorizedPayload = payload as VectorizedPayload<'default'>
+
+      const results = await vectorizedPayload.search({
+        query: titleAndQuery,
+        knowledgePool: 'default',
+        limit: 5,
+      })
+
+      expectValidVectorSearchResults(results, { checkShape: true })
+    })
+
+    test('search results are ordered by similarity (highest first)', async () => {
+      const vectorizedPayload = payload as VectorizedPayload<'default'>
+
+      const results = await vectorizedPayload.search({
+        query: titleAndQuery,
+        knowledgePool: 'default',
+        limit: 10,
+      })
+
+      expectResultsOrderedBySimilarity(results)
+    })
+
+    test('search respects limit parameter', async () => {
+      const vectorizedPayload = payload as VectorizedPayload<'default'>
+
+      const results = await vectorizedPayload.search({
+        query: titleAndQuery,
+        knowledgePool: 'default',
+        limit: 1,
+      })
+
+      expectResultsRespectLimit(results, 1)
+    })
+
+    test('search respects where clause', async () => {
+      const vectorizedPayload = payload as VectorizedPayload<'default'>
+
+      const results = await vectorizedPayload.search({
+        query: titleAndQuery,
+        knowledgePool: 'default',
+        where: {
+          docId: { equals: postId },
+        },
+        limit: 10,
+      })
+
+      expectResultsRespectWhere(results, (r) => r.docId === postId)
+    })
+
+    test('querying a title should return the title as top result', async () => {
+      const vectorizedPayload = payload as VectorizedPayload<'default'>
+
+      const results = await vectorizedPayload.search({
+        query: titleAndQuery,
+        knowledgePool: 'default',
+        limit: 10,
+      })
+
+      expectResultsContainTitle(results, titleAndQuery, postId, testEmbeddingVersion)
+    })
+  })
+
+  describe('queueEmbed method', () => {
+    test('payload has queueEmbed method', () => {
+      expect(typeof (payload as VectorizedPayload).queueEmbed).toBe('function')
+    })
+
+    test('queueEmbed queues a vectorization job', async () => {
+      const vectorizedPayload = payload as VectorizedPayload
+
+      // Create a post (triggers automatic embedding)
+      const post = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'Queue Embed Test Post',
+          content: markdownContent as unknown as any,
+        },
+      })
+
+      // Wait for automatic vectorization to complete
+      await waitForVectorizationJobs(payload)
+
+      // Call queueEmbed to queue another job
+      await vectorizedPayload.queueEmbed({
+        collection: 'posts',
+        docId: String(post.id),
+      })
+
+      // Check that a pending job was queued
+      const pendingJobs = await payload.find({
+        collection: 'payload-jobs',
+        where: {
+          and: [
+            { taskSlug: { equals: 'payloadcms-vectorize:vectorize' } },
+            { completedAt: { equals: null } },
+          ],
+        },
+      })
+
+      expect(pendingJobs.totalDocs).toBeGreaterThan(0)
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payloadcms-vectorize",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
   "type": "module",

--- a/src/endpoints/vectorSearch.ts
+++ b/src/endpoints/vectorSearch.ts
@@ -26,10 +26,27 @@ import type {
 } from 'payloadcms-vectorize'
 import { getEmbeddingsTable } from '../drizzle/tables.js'
 
-export const createVectorSearchHandler = <TPoolNames extends KnowledgePoolName>(
+export const createVectorSearchHandlers = <TPoolNames extends KnowledgePoolName>(
   knowledgePools: Record<TPoolNames, KnowledgePoolDynamicConfig>,
 ) => {
-  const _vectorSearch: PayloadHandler = async (req) => {
+  const vectorSearch = async (
+    payload: BasePayload,
+    query: string,
+    knowledgePool: TPoolNames,
+    limit?: number,
+    where?: Where,
+  ) => {
+    const poolConfig = knowledgePools[knowledgePool]
+    // Generate embedding for the query using pool-specific embedQuery
+    const queryEmbedding = await (async () => {
+      const qE = await poolConfig.embedQuery(query)
+      return Array.isArray(qE) ? qE : Array.from(qE)
+    })()
+
+    // Perform cosine similarity search using Drizzle
+    return await performCosineSearch(payload, queryEmbedding, knowledgePool, limit, where)
+  }
+  const requestHandler: PayloadHandler = async (req) => {
     if (!req || !req.json) {
       return Response.json({ error: 'Request is required' }, { status: 400 })
     }
@@ -60,27 +77,14 @@ export const createVectorSearchHandler = <TPoolNames extends KnowledgePoolName>(
 
       const payload = req.payload
 
-      // Generate embedding for the query using pool-specific embedQuery
-      const queryEmbedding = await (async () => {
-        const qE = await poolConfig.embedQuery(query)
-        return Array.isArray(qE) ? qE : Array.from(qE)
-      })()
-
-      // Perform cosine similarity search using Drizzle
-      const results = await performCosineSearch(
-        payload,
-        queryEmbedding,
-        knowledgePool,
-        limit,
-        where,
-      )
+      const results = await vectorSearch(payload, query, knowledgePool, limit, where)
 
       return Response.json({ results })
     } catch (error) {
       return Response.json({ error: 'Internal server error' }, { status: 500 })
     }
   }
-  return _vectorSearch
+  return { vectorSearch, requestHandler }
 }
 
 async function performCosineSearch(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,36 @@
 import type { CollectionSlug, Payload, Field, Where } from 'payload'
 
+/**
+ * Extended Payload type with vectorize plugin methods
+ */
+export type VectorizedPayload<TPoolNames extends KnowledgePoolName = KnowledgePoolName> =
+  Payload & {
+    search: (params: VectorSearchQuery<TPoolNames>) => Promise<Array<VectorSearchResult>>
+    queueEmbed: (
+      params:
+        | {
+            collection: string
+            docId: string
+          }
+        | {
+            collection: string
+            doc: Record<string, any>
+          },
+    ) => Promise<void>
+  }
+
+/**
+ * Type guard to check if a Payload instance has vectorize extensions
+ */
+export function isVectorizedPayload(payload: Payload): payload is VectorizedPayload {
+  return (
+    'search' in payload &&
+    typeof (payload as any).search === 'function' &&
+    'queueEmbed' in payload &&
+    typeof (payload as any).queueEmbed === 'function'
+  )
+}
+
 export type EmbedDocsFn = (texts: string[]) => Promise<number[][] | Float32Array[]>
 export type EmbedQueryFn = (text: string) => Promise<number[] | Float32Array>
 


### PR DESCRIPTION
Allows for VectorizedPayload.search and VectorizedPayload.queueEmbed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a local API on the Payload instance for programmatic vector search and embedding queueing.
> 
> - Adds `VectorizedPayload` with `payload.search(params)` and `payload.queueEmbed(params)`; exposes `isVectorizedPayload` type guard
> - Refactors vector search to `createVectorSearchHandlers` returning `{ vectorSearch, requestHandler }` for reuse
> - Hooks `onInit` to attach local methods; reuses collection hook logic via an internal embed-queue map
> - Updates `README.md` and `CHANGELOG.md` with usage docs and examples; bumps `package.json` to `0.4.5`
> - Adds/updates tests: `vectorizedPayload.spec.ts`, `vectorSearch.spec.ts`, `extensionFieldsVectorSearch.spec.ts`, `schemaName.spec.ts`, plus shared expectations helper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 243fef6a4710620a36736bd0c14f0e30789305cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->