### PR TITLE
Fixes failing test so we can publish

### DIFF
--- a/dev/specs/failedValidation.spec.ts
+++ b/dev/specs/failedValidation.spec.ts
@@ -4,7 +4,7 @@ import { getPayload } from 'payload'
 import { describe, expect, test } from 'vitest'
 
 import { createVectorizeIntegration } from '../../src/index.js'
-import { waitForVectorizationJobs } from './utils.js'
+import { createTestDb, waitForVectorizationJobs } from './utils.js'
 
 const DIMS = 8
 
@@ -18,8 +18,9 @@ const { afterSchemaInitHook, payloadcmsVectorize } = createVectorizeIntegration(
   },
 })
 
-const buildMalformedConfig = async () =>
-  buildConfig({
+const buildMalformedConfig = async () => {
+  await createTestDb({ dbName: 'failed_validation_test' })
+  return buildConfig({
     jobs: {
       tasks: [],
       autoRun: [
@@ -40,7 +41,8 @@ const buildMalformedConfig = async () =>
       afterSchemaInit: [afterSchemaInitHook],
       pool: {
         connectionString:
-          process.env.DATABASE_URI || 'postgresql://postgres:password@localhost:5433/payload_test',
+          process.env.DATABASE_URI ||
+          'postgresql://postgres:password@localhost:5433/failed_validation_test',
       },
     }),
     plugins: [
@@ -62,6 +64,7 @@ const buildMalformedConfig = async () =>
     ],
     secret: 'failed-validation-secret',
   })
+}
 
 describe('Validation failures mark jobs as errored', () => {
   test('malformed chunk entry fails the vectorize job', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of the failed validation test by isolating DB state and asserting expected error outcomes.
> 
> - Use `createTestDb` and point `connectionString` to `failed_validation_test` to isolate the database
> - Ensure vectorization job runs by enabling cron and `waitForVectorizationJobs`
> - Add assertions: latest `payload-jobs` entry for `payloadcms-vectorize:vectorize` has `hasError = true` with error mentioning `chunk` and `Invalid indices: 1`
> - Verify no embeddings were created by checking count in `default` collection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29f252603630e3c19207e7f55efb6f8fa7d2b61c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->