### PR TITLE
chore: clean Changesets output for root CHANGELOG

### DIFF
--- a/.changeset/fix-adapter-type-declarations.md
+++ b/.changeset/fix-adapter-type-declarations.md
@@ -1,4 +1,5 @@
 ---
+"payloadcms-vectorize": patch
 "@payloadcms-vectorize/pg": patch
 "@payloadcms-vectorize/cf": patch
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
 ## 0.7.1 - 2026-03-20
 
 ### Fixed


### PR DESCRIPTION
## Summary

PR #47 (the automatic Version Packages PR) produced an ugly root `CHANGELOG.md` diff: `## 0.7.2` was inserted **between** the `# Changelog` H1 and the intro paragraph, and had no bullet content because the changeset from #46 only named the adapter packages — the root was being silently pulled along by the `fixed` group with no narrative.

This PR fixes both issues so the next Version Packages PR is clean.

### Changes

- **`.changeset/fix-adapter-type-declarations.md`**: add `payloadcms-vectorize` to the frontmatter. With the `fixed` group in `.changeset/config.json`, the root was already being bumped — but Changesets only writes a narrative bullet for packages explicitly named in the changeset. Naming the root fixes the empty-section problem.
- **`CHANGELOG.md`**: remove the intro paragraph between `# Changelog` and the first version section. The default `@changesets/changelog-github` formatter inserts new content right after the H1, so anything between the H1 and the first `##` gets awkwardly sandwiched below the new release header.

### Expected output after merge

I ran `changeset:version` locally to preview. The root `CHANGELOG.md` now gets a proper entry:

```
# Changelog

## 0.7.2

### Patch Changes

- [#46](https://github.com/techiejd/payloadcms-vectorize/pull/46) [\`664b2b6\`](...) Thanks [@stevenlafl](...)! - Fix missing TypeScript declarations in \`@payloadcms-vectorize/pg\` and \`@payloadcms-vectorize/cf\`. The build now runs \`tsc\` before SWC...

## 0.7.1 - 2026-03-20
...
```

### Follow-up

PR #47 was closed and the `changeset-release/main` branch deleted so the release workflow regenerates a clean Version Packages PR when this one merges.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm `release.yml` fires, runs `changeset:version`, and opens a new "chore: version packages" PR.
- [ ] Review that new PR — root `CHANGELOG.md` should now have a full `## 0.7.2` section with PR link + @stevenlafl credit, not an empty header.
- [ ] Merge the Version Packages PR.
- [ ] Confirm `release.yml` fires again, `changeset publish` authenticates via Trusted Publishing OIDC, and all three packages publish at 0.7.2 on npm.