### PR TITLE
ci: upgrade npm in release.yml so Trusted Publishing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## Summary

- Node 20 on `ubuntu-latest` ships with npm 10.x
- npm Trusted Publishing (OIDC) requires **npm >= 11.5.1**
- Without the upgrade, `changeset publish` fails with 404s on `npm publish` even though the packages are configured as trusted publishers on npmjs.com

The last release workflow run after #47 merged failed exactly this way: all three packages at 0.7.2 have been versioned in-repo but never made it to the registry.

## Test plan

- [ ] Merge this PR
- [ ] release.yml fires on push to `main`, finds no pending changesets, runs `pnpm release` → `changeset publish`
- [ ] Verify `payloadcms-vectorize@0.7.2`, `@payloadcms-vectorize/pg@0.7.2`, `@payloadcms-vectorize/cf@0.7.2` land on npm