### PR TITLE
fix: add repository field so npm provenance passes

### DIFF
--- a/adapters/cf/package.json
+++ b/adapters/cf/package.json
@@ -3,6 +3,15 @@
   "version": "0.7.2",
   "description": "Cloudflare Vectorize adapter for payloadcms-vectorize",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/techiejd/payloadcms-vectorize.git",
+    "directory": "adapters/cf"
+  },
+  "homepage": "https://github.com/techiejd/payloadcms-vectorize/tree/main/adapters/cf#readme",
+  "bugs": {
+    "url": "https://github.com/techiejd/payloadcms-vectorize/issues"
+  },
   "type": "module",
   "files": [
     "dist"

--- a/adapters/pg/package.json
+++ b/adapters/pg/package.json
@@ -3,6 +3,15 @@
   "version": "0.7.2",
   "description": "PostgreSQL adapter for payloadcms-vectorize",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/techiejd/payloadcms-vectorize.git",
+    "directory": "adapters/pg"
+  },
+  "homepage": "https://github.com/techiejd/payloadcms-vectorize/tree/main/adapters/pg#readme",
+  "bugs": {
+    "url": "https://github.com/techiejd/payloadcms-vectorize/issues"
+  },
   "type": "module",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.7.2",
   "description": "A plugin to vectorize collections for RAG in Payload 3.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/techiejd/payloadcms-vectorize.git"
+  },
+  "homepage": "https://github.com/techiejd/payloadcms-vectorize#readme",
+  "bugs": {
+    "url": "https://github.com/techiejd/payloadcms-vectorize/issues"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- The previous release attempt (after #50) authenticated successfully via Trusted Publishing (good — npm upgrade worked!) but then failed with `E422` on all three packages:
  > Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: \"repository.url\" is \"\", expected to match \"https://github.com/techiejd/payloadcms-vectorize\" from provenance
- None of the three `package.json` files had a `repository` field. With `NPM_CONFIG_PROVENANCE=true`, npm requires it and must match the signed provenance.
- Adds `repository`, `homepage`, and `bugs` to the root package and both adapters (each adapter sets `directory` for a monorepo-aware link on npmjs.com).

## Test plan

- [ ] Merge this PR
- [ ] release.yml fires, no pending changesets, runs `changeset publish`
- [ ] All three packages publish successfully at 0.7.2