### PR TITLE
fix(vectorize): preserve chunks on embed failure + add i18n docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Payload CMS plugin that adds vector search capabilities to your collections. P
 - 🧩 **Extensible Schema** — attach custom [`extensionFields`](#knowledge-pool-config) to the embeddings collection and persist values per chunk for querying.
 - 🌐 [**REST API**](#rest-endpoints) — built-in vector-search endpoint with Payload-style [`where` filtering](#metadata-filtering-where) and configurable limits.
 - 🏊 [**Multiple Knowledge Pools**](#knowledge-pool-config) — separate knowledge pools with independent configurations.
+- 🌍 [**Localization (i18n)**](#localization-i18n) — first-class pattern for embedding and searching multi-locale Payload content.
 
 ## Table of Contents
 
@@ -34,6 +35,7 @@ A Payload CMS plugin that adds vector search capabilities to your collections. P
   - [CollectionVectorizeOption](#collectionvectorizeoption)
 - [Metadata Filtering (`where`)](#metadata-filtering-where)
 - [Chunkers](#chunkers)
+- [Localization (i18n)](#localization-i18n)
 - [Bulk Embeddings API](#bulk-embeddings-api)
 - [Validation & Retries](#validation--retries)
 - [API Reference](#api-reference)
@@ -397,6 +399,55 @@ const postsToKnowledgePool: ToKnowledgePoolFn = async (doc, payload) => {
 ```
 
 Because you control the output, you can mix different field types, discard empty values, or inject any metadata that aligns with your `extensionFields`.
+
+## Localization (i18n)
+
+Payload's localization works with this plugin out of the box. There is no dedicated `locale` config — locale-aware embedding and search is a first-class supported workflow built on the existing `extensionFields` and [`where` filter](#metadata-filtering-where) primitives.
+
+The pattern in three steps:
+
+**1. Declare `locale` as a required extension field on your knowledge pool:**
+
+```typescript
+extensionFields: [
+  { name: 'locale', type: 'text', required: true },
+  // ...other fields
+],
+```
+
+**2. Iterate locales inside `toKnowledgePool`** and tag each chunk with the locale it came from:
+
+```typescript
+const postsToKnowledgePool: ToKnowledgePoolFn = async (doc, payload) => {
+  const result: Array<{ chunk: string; locale: string }> = []
+  for (const locale of ['en', 'es', 'fr']) {
+    const localized = await payload.findByID({
+      collection: 'posts',
+      id: doc.id,
+      locale,
+    })
+    const chunks = await chunkText(localized.title ?? '', payload)
+    for (const chunk of chunks) {
+      result.push({ chunk, locale })
+    }
+  }
+  return result
+}
+```
+
+**3. Filter at search time** by the visitor's locale using the existing [`where` filter](#metadata-filtering-where):
+
+```typescript
+const results = await vectorizedPayload.search({
+  query: 'product warranty terms',
+  knowledgePool: 'mainKnowledgePool',
+  where: { locale: { equals: req.locale } },
+})
+```
+
+Visitors get locale-accurate semantic search: an English query returns English chunks, a Spanish query returns Spanish chunks, and the two never mix.
+
+**Tradeoff to know.** Every document save re-embeds every locale together. For CMS workloads this is usually fine — edits are infrequent, embeddings are cheap. If your workflow can't tolerate this (e.g. per-locale incremental re-embedding to control cost), see the [Roadmap](#roadmap) entry on scope-aware chunk identity and open an issue with your use case.
 
 ## Bulk Embeddings API
 
@@ -1022,6 +1073,7 @@ Common scripts:
 
 - **Additional adapters** — Pinecone, Qdrant, SQLite, etc. See [adapters/README.md](./adapters/README.md) for the `DbAdapter` contract.
 - **Vercel CI matrix** — exercising the serverless job model end-to-end on Vercel preview deployments.
+- **Scope-aware chunk identity** — `(sourceCollection, docId, ...scopeFields)` as identity for advanced editorial workflows: draft/published with locale, per-tenant isolation, A/B variants. Design is drafted (see [`docs/plans/archive/2026-05-10-scope-aware-chunk-identity.md`](./docs/plans/archive/2026-05-10-scope-aware-chunk-identity.md)). Waiting on a real use case before building — open an issue if this would unblock you.
 
 Want one of these sooner? Star the repo and open an issue.
 

--- a/dev/specs/vectorizeReorder.spec.ts
+++ b/dev/specs/vectorizeReorder.spec.ts
@@ -1,0 +1,146 @@
+import type { Payload } from 'payload'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { buildConfig, getPayload } from 'payload'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+
+import payloadcmsVectorize from 'payloadcms-vectorize'
+import { createMockAdapter } from 'helpers/mockAdapter.js'
+import { DIMS } from './constants.js'
+import { createTestDb, destroyPayload, waitForVectorizationJobs } from './utils.js'
+
+/**
+ * Verifies the safety invariant of the vectorize task ordering:
+ * if the embedding API fails on a re-embed, the doc's existing chunks
+ * must remain in the DB. The destructive delete must not run before
+ * we have valid embeddings ready to insert.
+ */
+describe('Vectorize task does not wipe existing chunks on embed failure', () => {
+  let payload: Payload
+  const dbName = 'vectorize_reorder_test'
+
+  // Controlled embed fn that can be made to fail mid-test.
+  let shouldEmbedFail = false
+  const embedDocs = async (texts: string[]) => {
+    if (shouldEmbedFail) {
+      throw new Error('Simulated embedding provider failure')
+    }
+    return texts.map(() => Array(DIMS).fill(0.5))
+  }
+  const embedQuery = async (_text: string) => Array(DIMS).fill(0)
+
+  beforeAll(async () => {
+    await createTestDb({ dbName })
+
+    const config = await buildConfig({
+      secret: 'reorder-test-secret',
+      editor: lexicalEditor(),
+      jobs: {
+        tasks: [],
+        autoRun: [{ cron: '*/2 * * * * *', limit: 10 }],
+      },
+      collections: [
+        {
+          slug: 'posts',
+          fields: [{ name: 'title', type: 'text' }],
+        },
+      ],
+      db: postgresAdapter({
+        pool: {
+          connectionString: `postgresql://postgres:password@localhost:5433/${dbName}`,
+        },
+      }),
+      plugins: [
+        payloadcmsVectorize({
+          dbAdapter: createMockAdapter(),
+          knowledgePools: {
+            default: {
+              collections: {
+                posts: {
+                  toKnowledgePool: async (doc: any) => [{ chunk: doc.title ?? '' }],
+                },
+              },
+              embeddingConfig: {
+                version: 'reorder-test-v1',
+                queryFn: embedQuery,
+                realTimeIngestionFn: embedDocs,
+              },
+            },
+          },
+        }),
+      ],
+    })
+
+    payload = await getPayload({
+      config,
+      key: `vectorize-reorder-test-${Date.now()}`,
+      cron: true,
+    })
+  })
+
+  afterAll(async () => {
+    await destroyPayload(payload)
+  })
+
+  test('existing chunks survive when re-embed fails', async () => {
+    // 1. Create a doc and let the first vectorize succeed.
+    const post = await payload.create({
+      collection: 'posts',
+      data: { title: 'Original title' } as any,
+    })
+    await waitForVectorizationJobs(payload)
+
+    const beforeFailure = await payload.find({
+      collection: 'default',
+      where: {
+        and: [
+          { sourceCollection: { equals: 'posts' } },
+          { docId: { equals: String(post.id) } },
+        ],
+      },
+    })
+    expect(beforeFailure.docs.length).toBeGreaterThan(0)
+    const originalIds = beforeFailure.docs.map((d: any) => d.id).sort()
+
+    // 2. Flip the embed fn to throw, then trigger a re-vectorize.
+    shouldEmbedFail = true
+    try {
+      await payload.update({
+        collection: 'posts',
+        id: post.id,
+        data: { title: 'Updated title' } as any,
+      })
+      await waitForVectorizationJobs(payload, 15000)
+
+      // 3. The job must have errored.
+      const failedJobs = await payload.find({
+        collection: 'payload-jobs',
+        where: {
+          and: [
+            { taskSlug: { equals: 'payloadcms-vectorize:vectorize' } },
+            { hasError: { equals: true } },
+          ],
+        },
+        sort: '-createdAt',
+        limit: 1,
+      })
+      expect(failedJobs.totalDocs).toBeGreaterThan(0)
+
+      // 4. The existing chunks must STILL be present, with the same IDs.
+      //    Before the reorder fix, deleteChunks ran first and wiped these.
+      const afterFailure = await payload.find({
+        collection: 'default',
+        where: {
+          and: [
+            { sourceCollection: { equals: 'posts' } },
+            { docId: { equals: String(post.id) } },
+          ],
+        },
+      })
+      const remainingIds = afterFailure.docs.map((d: any) => d.id).sort()
+      expect(remainingIds).toEqual(originalIds)
+    } finally {
+      shouldEmbedFail = false
+    }
+  })
+})

--- a/docs/plans/2026-05-10-scope-aware-chunk-identity.md
+++ b/docs/plans/2026-05-10-scope-aware-chunk-identity.md
@@ -1,0 +1,305 @@
+# Scope-Aware Chunk Identity
+
+**Date:** 2026-05-10
+**Status:** Design
+**Topic:** Generalize the locale-scoping problem so a single source document can produce multiple independent chunk-sets along any user-declared dimension (locale, draft/published, tenant, version, audience), without re-embedding one slice wiping the others.
+
+## Problem
+
+The plugin currently keys every chunk-set on `(sourceCollection, docId)`. This assumes one source doc produces one chunk-set. Re-embedding always wipes everything for that doc and re-inserts.
+
+That assumption breaks for any source doc that fans out into independent slices:
+
+- A localized doc with `en`, `es`, `fr` chunks. Re-embedding `en` today wipes the `es` and `fr` chunks.
+- Draft vs. published. Re-embedding the published version wipes the draft's embeddings.
+- Per-tenant variants of the same source.
+- A/B variants, region variants, audience variants.
+
+Today this is a latent bug for anyone using draft/published Payload collections; nobody has hit it yet because nobody has wired up locale-aware embeddings.
+
+## Mental Model
+
+A chunk-set has three kinds of data:
+
+1. **Identity.** What the chunk-set "is": the flat tuple `(sourceCollection, docId, ...scopeFields)`. With `scopeKey: ['locale']`, identity becomes `(sourceCollection, docId, locale)`. With `scopeKey: ['locale', 'tenant']`, it becomes `(sourceCollection, docId, locale, tenant)`. Two chunk-sets that share `(sourceCollection, docId)` but differ on any scope field are independent and never collide.
+2. **Scope.** Carried through the framework as `scope: Record<string, any>`, e.g. `{ locale: 'en', tenant: 'acme' }`. The keys come from the pool's `scopeKey` declaration. The values come from each chunk's extension fields. Semantically, scope spreads into the composite primary key; the `Record` is just the wire format because the keys are pool-defined and dynamic.
+3. **Metadata.** Everything else in `extensionFields`. Queryable, displayable in admin, but not part of identity. Re-embedding does not key on metadata.
+
+**Invariant:** every adapter operation on a chunk-set keys on the full identity tuple `(sourceCollection, docId, ...scopeFields)`. No partial-key writes, no partial-key deletes. Cross-scope wipes are impossible by construction.
+
+A pool with no `scopeKey` declared has scope `= {}` and behaves byte-identically to the current plugin.
+
+## Pool Config
+
+`KnowledgePoolConfig` gains one optional field:
+
+```ts
+{
+  extensionFields: [
+    { name: 'locale', type: 'text', required: true },
+    { name: 'category', type: 'text' },
+  ],
+  scopeKey: ['locale'],
+}
+```
+
+Validation at plugin init (alongside the existing `RESERVED_FIELDS` check in `src/collections/embeddings.ts`):
+
+- Every name in `scopeKey` must reference an existing entry in `extensionFields`. Otherwise throw.
+- Every scope-key extension field must be declared `required: true`. Otherwise throw. This guarantees Payload's own required-field validation enforces non-null at insert time, so the framework does not need to duplicate it.
+- `scopeKey` must not contain any reserved field name (`sourceCollection`, `docId`, `chunkIndex`, `chunkText`, `embeddingVersion`).
+
+If `scopeKey` is absent or `[]`, pool behavior is unchanged.
+
+## Embeddings Collection Index
+
+`src/collections/embeddings.ts` currently declares:
+
+```ts
+indexes: [{ fields: ['sourceCollection', 'docId'] }]
+```
+
+This becomes:
+
+```ts
+indexes: [{ fields: ['sourceCollection', 'docId', ...scopeKey] }]
+```
+
+For pools without `scopeKey`, the index is byte-identical to today. For pools with scope, the composite index covers the full identity tuple. Payload's normal migration system emits the DDL.
+
+## Adapter Contract
+
+`src/types.ts`:
+
+```ts
+export type StoreChunkData = {
+  sourceCollection: string
+  docId: string
+  scope: Record<string, any>          // NEW
+  chunkIndex: number
+  chunkText: string
+  embeddingVersion: string
+  embedding: number[] | Float32Array
+  extensionFields: Record<string, any>
+}
+
+export type DbAdapter = {
+  // ...
+  storeChunk: (payload, poolName, data: StoreChunkData) => Promise<void>
+
+  deleteChunks: (
+    payload, poolName,
+    sourceCollection: string,
+    docId: string,
+    scope: Record<string, any>,        // NEW, required, may be {}
+  ) => Promise<void>
+
+  hasEmbeddingVersion: (
+    payload, poolName,
+    sourceCollection: string,
+    docId: string,
+    embeddingVersion: string,
+    scope: Record<string, any>,        // NEW, required, may be {}
+  ) => Promise<boolean>
+
+  // search() unchanged. Callers can already filter on scope fields via `where`.
+}
+```
+
+Two notes on `StoreChunkData`:
+
+- `scope` and `extensionFields` deliberately overlap. `extensionFields.locale === scope.locale`. The vectorize task is responsible for synthesizing `scope` from each chunk's scope-key extension-field values before calling `storeChunk`; adapters consume both fields as given and do not re-derive scope from `extensionFields`. `extensionFields` keeps the scope keys queryable and admin-visible; `scope` gives the adapter explicit identity without it having to read `pool.scopeKey`.
+- `scope` is required, possibly `{}`. Callers cannot omit it. An optional `scope?` invites silent forgetting; required-but-empty makes the "no scope" decision explicit at every callsite.
+
+## toKnowledgePool Author Surface
+
+No signature change. `toKnowledgePool` still returns `Array<{ chunk: string, ...extensionFieldValues }>`.
+
+What changes is the author's responsibility: with `scopeKey: ['locale']` declared, every returned chunk must include `locale`. The framework derives `scope` from each chunk by picking the scope-key fields off the returned object.
+
+```ts
+toKnowledgePool: async (doc, payload) => {
+  const result = []
+  for (const locale of ['en', 'es', 'fr']) {
+    const localized = await payload.findByID({ collection, id: doc.id, locale })
+    result.push(
+      { chunk: localized.title, locale },
+      { chunk: localized.body,  locale },
+    )
+  }
+  return result
+}
+```
+
+There is no per-chunk scope-value validation in the framework. Payload's required-field check at `storeChunk` time catches missing or null values with a clear error. Type mismatches are caught the same way (e.g. `locale: 0` for a `text` field). The only framework-level scope validation is the pool-config check at plugin init described above.
+
+## Vectorize Task Algorithm
+
+`src/tasks/vectorize.ts` becomes:
+
+```ts
+async function runVectorizeTask({ adapter, dynamicConfig, job, payload, poolName }) {
+  const { embeddingConfig } = dynamicConfig
+  const collection = job.collection
+  const sourceDoc = job.doc
+  const collectionConfig = dynamicConfig.collections[collection]
+  if (!collectionConfig) throw new Error(/* ... */)
+
+  // 1. Read + generate (pure)
+  const chunkData = await collectionConfig.toKnowledgePool(sourceDoc, payload)
+  validateChunkData(chunkData, String(sourceDoc.id), collection)
+
+  // 2. Embed (external API; failure here leaves DB untouched)
+  const chunkTexts = chunkData.map(c => c.chunk)
+  const vectors = await embeddingConfig.realTimeIngestionFn!(chunkTexts)
+
+  // 3. Group by scope
+  const scopeKey = dynamicConfig.scopeKey ?? []
+  const groups = groupByScope(chunkData, vectors, scopeKey)
+
+  // 4. Per-scope: delete-then-insert (the invariant)
+  for (const { scope, items } of groups) {
+    await adapter.deleteChunks(payload, poolName, collection, String(sourceDoc.id), scope)
+    await Promise.all(items.map(({ chunk, vector, index, ext }) =>
+      adapter.storeChunk(payload, poolName, {
+        sourceCollection: collection,
+        docId: String(sourceDoc.id),
+        scope,
+        chunkIndex: index,
+        chunkText: chunk,
+        embeddingVersion: embeddingConfig.version,
+        embedding: vector,
+        extensionFields: ext,
+      })
+    ))
+  }
+}
+```
+
+### Two Behavioral Changes
+
+**Reorder.** Today the order is `delete → toKnowledgePool → validate → embed → store`. The wipe happens first. Any failure in `toKnowledgePool`, validation, or embedding leaves the doc with no embeddings until someone fixes the bug and re-triggers.
+
+The new order is `toKnowledgePool → validate → embed → delete → store`. The destructive step happens only after we have valid embeddings ready to insert. This is a general safety win independent of scope: an embedding-provider rate-limit error no longer wipes the doc's existing embeddings. The window between delete and the end of the per-scope `Promise.all` still allows partial-failure gaps; closing that fully needs an adapter-level transaction across delete+store and is out of scope here.
+
+**Group by scope.** Each unique scope value gets its own delete-then-insert cycle. Re-embedding the `en` slice never touches the `es` slice.
+
+### `groupByScope` Helper
+
+```ts
+// `pick(obj, keys)` returns a new object containing only those keys (lodash-style).
+// `stableStringify(obj)` sorts keys before stringifying so key order does not
+// affect grouping. Inline 4-line helpers; no new dependency.
+
+function groupByScope(chunkData, vectors, scopeKey) {
+  if (scopeKey.length === 0) {
+    // Fast path: single group, scope = {}, indices unchanged.
+    // No scope/extension split needed because there are no scope keys to extract.
+    return [{
+      scope: {},
+      items: chunkData.map(({ chunk, ...ext }, i) => ({
+        chunk, ext, vector: vectors[i], index: i,
+      })),
+    }]
+  }
+  const map = new Map<string, { scope: Record<string, any>; items: Item[] }>()
+  chunkData.forEach(({ chunk, ...rest }, i) => {
+    const scope = pick(rest, scopeKey)
+    const key = stableStringify(scope)
+    if (!map.has(key)) map.set(key, { scope, items: [] })
+    const group = map.get(key)!
+    group.items.push({
+      chunk,
+      ext: rest,                  // includes scope-key fields, for queryability
+      vector: vectors[i],
+      index: group.items.length,
+    })
+  })
+  return [...map.values()]
+}
+```
+
+Two design points:
+
+- **`chunkIndex` is per-scope, not global.** Two `en` chunks get indices `0, 1`; two `es` chunks also get `0, 1`. `chunkIndex` is meaningful within a chunk-set, and chunk-sets are per-scope. Re-embedding `en` with the same chunk count produces identical `chunkIndex` values to before, so no churn.
+- **Stable scope serialization.** `stableStringify` sorts keys before stringifying so `{locale:'en',tenant:'a'}` and `{tenant:'a',locale:'en'}` group together. A small inline helper is fine; no new dependency needed.
+
+## Bulk Embed Pipeline
+
+`src/utils/deleteDocumentEmbeddings.ts` gains a `scope: Record<string, any>` argument (required, may be `{}`) and forwards it to `adapter.deleteChunks`.
+
+`src/tasks/bulkEmbedAll.ts` applies the same group-by-scope reorder when persisting batch results: chunks coming back from a batch are grouped by scope, and each group runs delete-then-insert independently. The exact integration point depends on how the bulk-batch result handler is structured; the planning phase should map this in detail. The intent is identical to the per-doc path: every delete operates on the full identity tuple.
+
+## pg Adapter Implementation
+
+`adapters/pg/src/index.ts` `deleteChunks` currently builds:
+
+```ts
+where: { and: [
+  { sourceCollection: { equals: sourceCollection } },
+  { docId:            { equals: String(docId)    } },
+]}
+```
+
+It gains additional clauses, one per scope key:
+
+```ts
+where: { and: [
+  { sourceCollection: { equals: sourceCollection } },
+  { docId:            { equals: String(docId)    } },
+  ...Object.entries(scope).map(([k, v]) => ({ [k]: { equals: v } })),
+]}
+```
+
+Same shape change for `hasEmbeddingVersion`. No new SQL machinery. The existing where-translation in `adapters/pg/src/search.ts` already handles arbitrary equality predicates on extension-field columns.
+
+`storeChunk` reads `data.extensionFields` as today; the scope-key columns are populated through that path. The new `data.scope` field is for the adapter to use when building queries (it does not need to re-derive scope from `extensionFields`).
+
+## Migration & Backward Compatibility
+
+**Pools without `scopeKey`.** Behavior is byte-identical to today. The composite index has the same columns. Adapters receive `scope: {}` on every call. No DB migration. No code change for downstream users beyond the major version bump.
+
+**Adapter contract is breaking, so this is a major version bump.** `deleteChunks` and `hasEmbeddingVersion` add a required parameter; `StoreChunkData` adds a required field. Every adapter (pg, mongo) must update. Downstream consumers writing custom adapters get a TypeScript error pointing them at exactly what changed.
+
+**Pools opting in on a non-empty embeddings table.** This is the only non-trivial migration case. The user must:
+
+1. Ensure the chosen scope-key extension field already exists and is `required: true` on the pool.
+2. Backfill any existing embedding rows where that column is null. Plugin init will throw if the field is not `required`, and Payload will throw at insert time on null values, so this step must happen before the new config is deployed.
+3. Add `scopeKey: ['locale']` to the pool config and deploy. Payload's normal migration system updates the composite index DDL.
+
+The README documents this prerequisite. The plugin does not automate the backfill (it is domain-specific: what value should null-locale rows get?).
+
+**No data shape changes.** Embeddings rows on disk look the same. The change is to the index columns and to which clauses appear in delete/version-check WHEREs.
+
+## Testing
+
+This section lists only what the change adds. Existing specs that already cover the surface (search where-clause filtering, basic vectorize task behavior on a no-scope pool, etc.) should be re-run to confirm no regression but do not need new tests written.
+
+**Unit tests:**
+
+- `groupByScope` helper: no scope (single `{}` group, indices unchanged), single-key scope, multi-key scope, stable key ordering, preserves chunk order within group, per-group `chunkIndex` numbering starts at 0.
+- Plugin init: `scopeKey` referencing missing `extensionField` throws; non-`required` `extensionField` throws; reserved-field overlap throws; valid config does not throw.
+
+**Integration tests** in `dev/specs/`:
+
+- **Scope isolation (the bug fix):** pool with `scopeKey: ['locale']`, embed a doc once with `en` and `es` chunks, re-trigger vectorize on the doc with only `en` chunks regenerated, assert `es` chunks remain in the DB unchanged.
+- **Reorder safety:** mock `realTimeIngestionFn` to throw on a doc that already has embeddings, assert the existing chunks are still present after the failure (no destructive delete happened).
+- **Bulk embed scope-aware:** run a bulk embed against a multi-scope pool, assert each scope group is independently delete-and-replaced (no cross-scope wipe).
+- **Hard-fail on missing scope value:** chunk returned without the declared scope field. Payload's required-field validation throws at `storeChunk`. Because of the reorder, no rows have been wiped at the point of failure.
+
+**Adapter test parity:** the scope tests above run against both the pg and mongo adapters. A shared test helper in `dev/specs/` exports the scenarios so each adapter's test suite consumes the same matrix. This is required, not optional.
+
+## README Updates
+
+Two additions:
+
+1. **"Scope-aware chunk identity" section** documenting the `scopeKey` pool config, the `(sourceCollection, docId, ...scopeFields)` identity model, when to use it (locale, draft/published, tenant, etc.), and the migration prerequisite for opt-in on existing data.
+2. **"Scope gotchas" subsection** covering the silent-bucket trap:
+
+   > Any defined value is a valid scope, including `''`, `0`, and `false` (subject to the declared field type). If your `toKnowledgePool` returns `{ chunk, locale: '' }` for some chunks and `{ chunk, locale: 'en' }` for others, those go into two independent chunk-sets. Re-embedding the `'en'` set will not wipe the `''` set. Make sure your `toKnowledgePool` populates every declared scope field with the value you actually mean.
+
+## Out of Scope
+
+- A public `vectorizeDocument(doc, {scope})` API that re-embeds only one slice. Possible future addition; not needed for v1.
+- Adapter-level transactions across delete+store. The reorder closes most of the safety gap; closing the rest is a separate concern.
+- Automated backfill tooling for pools opting into `scopeKey` on existing data. Domain-specific; documented as a manual step.

--- a/docs/plans/2026-05-13-vectorize-safety-and-localization-docs.md
+++ b/docs/plans/2026-05-13-vectorize-safety-and-localization-docs.md
@@ -1,0 +1,105 @@
+# Vectorize Task Safety Reorder + Localization Docs
+
+**Date:** 2026-05-13
+**Status:** Design
+**Topic:** Two small, independently-valuable changes split off from the parked scope-aware-chunk-identity spec. Ship together because they share a release story.
+
+## Background
+
+A separate brainstorming session (see [archive/2026-05-10-scope-aware-chunk-identity.md](archive/2026-05-10-scope-aware-chunk-identity.md)) explored generalizing the locale-scoping problem into a first-class `scopeKey` config. We concluded that full feature is YAGNI for now: the locale case (the dominant motivator) is already solvable with the existing extension-field + `where` pattern, and the remaining motivators (draft/published with locale, per-tenant isolation, A/B variants) are rare enough to defer until a user reports the gap.
+
+Two pieces of that work are valuable on their own and ship here:
+
+1. The **vectorize task reorder** is a general safety improvement, unrelated to scope.
+2. The **README "Localization" section** turns the existing capability into a discoverable feature and neutralizes competitor positioning that markets "locale-scoped semantic search" as a differentiator.
+
+A third small piece — a **Roadmap line** about scope-aware identity — converts the parked spec into a market-research signal: if users file issues citing it, that surfaces real demand and unparks the spec.
+
+## Change 1: Vectorize Task Reorder
+
+### Problem
+
+`src/tasks/vectorize.ts` currently runs in this order:
+
+```
+deleteChunks  →  toKnowledgePool  →  validateChunkData  →  embed  →  storeChunk
+```
+
+The destructive step (`deleteChunks`) happens first. Any failure in `toKnowledgePool`, validation, or the external embedding API leaves the doc with **no embeddings at all** until someone fixes the underlying issue and re-triggers. The most common real-world cause is a transient embedding-provider failure (rate limit, network blip, malformed input), which silently wipes a doc's chunks until the next save.
+
+### Fix
+
+Reorder to:
+
+```
+toKnowledgePool  →  validateChunkData  →  embed  →  deleteChunks  →  storeChunk
+```
+
+The destructive step now runs only after we have valid embeddings ready to insert. A rate-limit error fails the task without touching the DB; the next retry rebuilds cleanly with the existing chunks intact in the meantime.
+
+Concretely, in [src/tasks/vectorize.ts:83-123](src/tasks/vectorize.ts#L83-L123), move the `await adapter.deleteChunks(...)` call from before `toKnowledgePoolFn(...)` to just before the `Promise.all` over `storeChunk(...)`.
+
+### Residual gap (out of scope)
+
+A window between `deleteChunks` and the end of the `storeChunk` `Promise.all` still allows partial failures to leave the doc partially-embedded. Closing this fully needs an adapter-level transaction across delete+store. That is a separate, larger change; the reorder alone removes the much more common failure mode (pre-delete failures) at near-zero cost.
+
+### Bulk embed path
+
+[src/tasks/bulkEmbedAll.ts](src/tasks/bulkEmbedAll.ts) uses [src/utils/deleteDocumentEmbeddings.ts](src/utils/deleteDocumentEmbeddings.ts) at batch-completion time. The same reorder principle applies: the delete should happen only after the batch result has been validated and the embeddings are ready to write. Planning phase should map the exact call site; the change is conceptually identical to the per-doc path.
+
+## Change 2: README "Localization" Section
+
+### Problem
+
+A Payload developer evaluating vector-search plugins wants to know whether the plugin supports multi-locale content. Today's README has no "Localization" anchor in the TOC, no example, no mention of the `where` filter pattern for locale-aware search. A reasonable evaluator concludes the plugin doesn't support i18n and chooses a competitor that markets the feature explicitly — even though the underlying capability is identical.
+
+### Fix
+
+Add a new top-level section between [Chunkers](README.md#chunkers) and [Bulk Embeddings API](README.md#bulk-embeddings-api), titled **"Localization (i18n)"**, that walks through the recommended pattern end-to-end:
+
+1. **Declare `locale` as a required extension field** on the knowledge pool.
+2. **Iterate locales inside `toKnowledgePool`**, returning all-locale chunks tagged with `locale`. Provide a working snippet using `payload.findByID({ locale })`.
+3. **Filter at search time** with `where: { locale: { equals: req.locale } }` (link to the existing [Metadata Filtering](README.md#metadata-filtering-where) section).
+4. **Note the tradeoff**: every edit re-embeds every locale together. For most CMS workloads this is a non-issue (edits are infrequent, embeddings are cheap). If a user's workflow can't tolerate this, point them at the Roadmap line (Change 3) to file an issue.
+
+Add the section to the TOC at line 36 (between `Metadata Filtering` and `Chunkers`) and add a Features bullet near the top of the README so the capability is discoverable from the first scroll. Suggested bullet: `🌍 **Localization (i18n)** — first-class pattern for embedding and searching multi-locale Payload content.`
+
+The section is ~50 lines of prose plus the snippet. Self-contained; no other README rewrites required.
+
+## Change 3: Roadmap Signal for Scope-Aware Identity
+
+### Problem
+
+The parked spec is a complete design for a real-but-niche capability. Burying it in the archive folder means we never hear from the users who would benefit. We want a low-cost mechanism that surfaces real demand without committing to build.
+
+### Fix
+
+Add one line to the **Help wanted** subsection of [README.md#roadmap](README.md#roadmap) (around line 1021-1025):
+
+> - **Scope-aware chunk identity** — `(sourceCollection, docId, …scopeFields)` as identity for advanced editorial workflows: draft/published with locale, per-tenant isolation, A/B variants. Design is drafted (see `docs/plans/archive/`). Waiting on a real use case before building — open an issue if this would unblock you.
+
+This converts the parked spec into a market-research instrument. Issues citing it go straight to the prioritization queue, and the link to the archived design gives interested users (and future-us) a starting point.
+
+## Out of Scope
+
+- The `scopeKey` config field, contract redesign, per-scope delete-and-replace algorithm, and adapter changes. All preserved in the archived spec; deferred pending user demand.
+- Adapter-level transactions across delete+store.
+- Backfill tooling for any future scope-key opt-in.
+
+## Testing
+
+**Change 1 (reorder):**
+
+- New integration test in `dev/specs/`: vectorize a doc, then trigger another vectorize where `realTimeIngestionFn` is mocked to throw. Assert that the existing chunks for the doc are still present after the failure. (This is the test that exercises the bug the reorder fixes; it should fail on the current `main` and pass after the change.)
+- Re-run existing vectorize specs to confirm no regression for the happy path.
+
+**Changes 2 and 3 (README only):**
+
+- No code tests. Manual review of rendered Markdown (GitHub preview) before merge to verify the TOC anchor resolves and the snippet is copy-pasteable.
+
+## Release Notes
+
+- Patch or minor bump (no API change). Changelog entry framing:
+  > **Vectorize task safety:** embedding-provider failures no longer wipe a doc's existing embeddings. The vectorize task now generates, validates, and embeds chunks before deleting the old chunk-set, so transient errors leave the previous chunks intact for the next retry.
+  >
+  > **Localization docs:** new README section covers the recommended pattern for embedding and searching multi-locale Payload content using extension fields and the existing `where` filter.

--- a/docs/plans/archive/2026-05-10-scope-aware-chunk-identity.md
+++ b/docs/plans/archive/2026-05-10-scope-aware-chunk-identity.md
@@ -1,8 +1,18 @@
 # Scope-Aware Chunk Identity
 
 **Date:** 2026-05-10
-**Status:** Design
+**Status:** Parked (archived 2026-05-13) — see note below
 **Topic:** Generalize the locale-scoping problem so a single source document can produce multiple independent chunk-sets along any user-declared dimension (locale, draft/published, tenant, version, audience), without re-embedding one slice wiping the others.
+
+---
+
+> **Archive note (2026-05-13)**
+>
+> This spec is preserved as a complete design but is **not scheduled for implementation**. After reviewing the actual use-case prevalence in the Payload ecosystem, we concluded that the locale case (the dominant motivator) is already solvable via the existing extension-field + `where` pattern — see the "Localization" section added to the README. The remaining motivator (draft/published with locale, per-tenant isolation, A/B variants) is real but rare enough that we are waiting for a user-filed issue before building.
+>
+> The **vectorize task reorder** described in this spec's "Vectorize Task Algorithm" section has independent value and has been extracted to [2026-05-13-vectorize-safety-and-localization-docs.md](../2026-05-13-vectorize-safety-and-localization-docs.md). That ships separately.
+>
+> When a user reports a workflow that requires scope isolation, revive this spec, re-validate the design against the reported use case, and proceed to writing-plans. The recommended shape at revival time is the **additive** variant (Alternative 2 in the brainstorming session): `scope?` optional everywhere, no breaking change. The "required-but-empty" purity in the design below should be relaxed at that point.
 
 ## Problem
 

--- a/src/tasks/vectorize.ts
+++ b/src/tasks/vectorize.ts
@@ -92,11 +92,6 @@ async function runVectorizeTask(args: {
   }
   const toKnowledgePoolFn: ToKnowledgePoolFn = collectionConfig.toKnowledgePool
 
-  // Delete all existing embeddings for this document before creating new ones
-  // This ensures we replace old embeddings (potentially with a different embeddingVersion)
-  // and prevents duplicates when a document is updated
-  await adapter.deleteChunks(payload, poolName, collection, String(sourceDoc.id))
-
   // Get chunks from toKnowledgePoolFn
   const chunkData = await toKnowledgePoolFn(sourceDoc, payload)
 
@@ -105,6 +100,11 @@ async function runVectorizeTask(args: {
   // Extract chunk texts for embedding
   const chunkTexts = chunkData.map((item) => item.chunk)
   const vectors = await dynamicConfig.embeddingConfig.realTimeIngestionFn!(chunkTexts)
+
+  // Delete existing embeddings only after we have valid vectors ready to insert.
+  // If toKnowledgePool, validation, or the embedding API fails above, the doc's
+  // existing chunks remain intact for the next retry.
+  await adapter.deleteChunks(payload, poolName, collection, String(sourceDoc.id))
 
   // Create embedding documents with extension field values
   await Promise.all(


### PR DESCRIPTION
## Summary

Two independently-valuable changes split off from the parked scope-aware-chunk-identity brainstorming (see [docs/plans/2026-05-13-vectorize-safety-and-localization-docs.md](docs/plans/2026-05-13-vectorize-safety-and-localization-docs.md) for the full story).

- **`fix(vectorize)`** — reorder the vectorize task so `deleteChunks` runs *after* `toKnowledgePool`, validation, and the external embedding API succeed. Previously a transient rate-limit or network failure during embedding would silently wipe a doc's existing chunks until the next save. Now those failures leave the previous chunks intact for the next retry.
- **`docs(readme)`** — add a "Localization (i18n)" section that surfaces the existing locale-aware embedding/search workflow as a first-class pattern (declare `locale` as a required extension field, iterate locales inside `toKnowledgePool`, filter at search time via the existing `where` filter). Adds a Features bullet, TOC entry, and a Roadmap "Help wanted" line for scope-aware chunk identity that links to the archived design spec.
- **`docs(spec)`** — design docs for the scope-aware-chunk-identity exploration that ultimately got parked as YAGNI, plus the split-spec that produced this PR. Archived design is at [docs/plans/archive/2026-05-10-scope-aware-chunk-identity.md](docs/plans/archive/2026-05-10-scope-aware-chunk-identity.md).

No public API change. Patch bump warranted for the safety fix.

## Test plan

- [x] New integration test [dev/specs/vectorizeReorder.spec.ts](dev/specs/vectorizeReorder.spec.ts) — fails on the prior task ordering (asserts existing chunks survive an embed failure); passes after the reorder.
- [x] Full int suite passes locally (`pnpm test:int`): 27 files, 68 tests, no regressions.
- [x] Manual README review in GitHub preview to confirm the new Localization anchor resolves from the TOC and the Roadmap link points at the archived spec.
- [ ] Changeset entry to be added before next release (patch bump for the vectorize safety fix).