### PR TITLE
chore(changeset): patch bump for vectorize reorder fix

### DIFF
--- a/.changeset/vectorize-reorder-preserve-chunks.md
+++ b/.changeset/vectorize-reorder-preserve-chunks.md
@@ -1,0 +1,8 @@
+---
+"payloadcms-vectorize": patch
+"@payloadcms-vectorize/pg": patch
+"@payloadcms-vectorize/cf": patch
+"@payloadcms-vectorize/mongodb": patch
+---
+
+Fix: reorder the vectorize task so existing chunks are deleted only after `toKnowledgePool` + embeddings succeed. Previously, a transient embedding-provider failure during re-vectorization would wipe a document's existing chunks before the new ones were ready, leaving the document temporarily unsearchable. Also documents a first-class Localization (i18n) pattern in the README.


### PR DESCRIPTION
## Summary
- Adds a Changeset for the merged vectorize-task reorder fix (PR #54) so the next Changesets version bump cuts a patch release.
- Patch bump across all fixed packages (`payloadcms-vectorize`, `@payloadcms-vectorize/pg`, `@payloadcms-vectorize/cf`, `@payloadcms-vectorize/mongodb`).
- Note: matches the pattern from 8b338e6 — `fixed` group + pre-1.0 versions promote `minor` to a major bump, so `patch` is the right level for a non-breaking fix.

## Test plan
- [ ] Verify `.changeset/vectorize-reorder-preserve-chunks.md` lists all 4 packages as `patch`.
- [ ] Confirm the Changesets release bot opens a "version packages" PR with the expected 0.0.1 bump after merge.