### PR TITLE
feat(rerank): per-pool rerank callback for vector search

### DIFF
--- a/.changeset/rerank-callback.md
+++ b/.changeset/rerank-callback.md
@@ -1,0 +1,8 @@
+---
+"payloadcms-vectorize": minor
+"@payloadcms-vectorize/pg": minor
+"@payloadcms-vectorize/cf": minor
+"@payloadcms-vectorize/mongodb": minor
+---
+
+Add optional `rerank` callback on `EmbeddingConfig` for per-pool reranking. When configured, the plugin fetches `Math.floor(limit * multiplier)` candidates from the adapter, hands them to the user-supplied callback (`(query, results) => Promise<results>`), and trims the callback's output back down to the caller's `limit`. Provider-agnostic — bring your own Voyage / Cohere / local cross-encoder. `multiplier` must be a finite number `>= 1`; invalid configs are rejected at plugin init. Callback errors propagate to the caller.

--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ if (vectorizedPayload) {
 
 #### `vectorizedPayload.search(params)`
 
-Perform vector search programmatically without making an HTTP request. Parameters and result shape are identical to [POST `/api/vector-search`](#post-apivector-search).
+Perform vector search programmatically without making an HTTP request. Parameters and result shape are identical to [POST `/api/vector-search`](#post-apivector-search). If the pool has a [`rerank`](#reranking-optional) config, this call goes through the same rerank pipeline as the REST endpoint.
 
 **Returns:** `Promise<Array<VectorSearchResult>>` — the array that the REST endpoint wraps in `{ results }`.
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ embeddingConfig: {
 }
 ```
 
-The plugin trims the callback's output to the caller's `limit`. Errors thrown by the callback propagate to the caller. `multiplier` must be a finite number `>= 1`; invalid configs are rejected at plugin init.
+The plugin trims the callback's output to the caller's `limit`. Errors thrown by the callback propagate to the caller. `multiplier` must be a finite number `>= 1`; invalid configs are rejected at plugin init. If `limit` is omitted, the rerank branch falls back to a default of `10` for fetch sizing.
 
 ## Chunkers
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,33 @@ References to fields that don't exist on the embeddings table are silently dropp
 
 > **Adapter parity.** All operators are implemented in `@payloadcms-vectorize/pg`. The Cloudflare Vectorize adapter has narrower native filtering — see [@payloadcms-vectorize/cf → Known Limitations](./adapters/cf/README.md#metadata-filtering) for what is and isn't supported there. The MongoDB adapter splits the clause into a native `$vectorSearch` pre-filter and a JS post-filter — `like`/`contains`/`all` and any mixed-pre/post `or` are post-filtered, so they may return fewer than `limit` rows. See [@payloadcms-vectorize/mongodb → WHERE clause behavior](./adapters/mongodb/README.md#where-clause-behavior).
 
+## Reranking (optional)
+
+Pass a `rerank` config on a pool's `embeddingConfig` to reorder candidates with your own reranker (e.g. Voyage, Cohere, a local cross-encoder):
+
+```ts
+embeddingConfig: {
+  version: 'v1',
+  queryFn,
+  realTimeIngestionFn,
+  rerank: {
+    // DB fetches Math.floor(limit * multiplier) candidates before reranking.
+    // Higher multiplier = better recall, more latency, more cost.
+    multiplier: 4,
+    callback: async (query, results) => {
+      const ranked = await myReranker.rerank({
+        query,
+        documents: results.map((r) => r.chunkText),
+      })
+      // Return VectorSearchResults in your desired order.
+      return ranked.map((r) => results[r.index])
+    },
+  },
+}
+```
+
+The plugin trims the callback's output to the caller's `limit`. Errors thrown by the callback propagate to the caller. `multiplier` must be a finite number `>= 1`; invalid configs are rejected at plugin init.
+
 ## Chunkers
 
 Use chunker helpers (see `dev/helpers/chunkers.ts`) to keep `toKnowledgePool` implementations focused on orchestration. A `toKnowledgePool` can combine multiple chunkers, enrich each chunk with metadata, and return everything the embeddings collection needs.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Payload CMS plugin that adds vector search capabilities to your collections. P
 - 🎯 [**Flexible Chunking**](#chunkers) — drive chunk creation yourself with `toKnowledgePool` functions so you can combine any fields or content types.
 - 🧩 **Extensible Schema** — attach custom [`extensionFields`](#knowledge-pool-config) to the embeddings collection and persist values per chunk for querying.
 - 🌐 [**REST API**](#rest-endpoints) — built-in vector-search endpoint with Payload-style [`where` filtering](#metadata-filtering-where) and configurable limits.
+- 🎚️ [**Optional Reranking**](#reranking-optional) — bring your own reranker (Voyage, Cohere, local cross-encoder) to reorder candidates after the vector search.
 - 🏊 [**Multiple Knowledge Pools**](#knowledge-pool-config) — separate knowledge pools with independent configurations.
 - 🌍 [**Localization (i18n)**](#localization-i18n) — first-class pattern for embedding and searching multi-locale Payload content.
 
@@ -34,6 +35,7 @@ A Payload CMS plugin that adds vector search capabilities to your collections. P
   - [Adapter Configuration](#adapter-configuration)
   - [CollectionVectorizeOption](#collectionvectorizeoption)
 - [Metadata Filtering (`where`)](#metadata-filtering-where)
+- [Reranking (optional)](#reranking-optional)
 - [Chunkers](#chunkers)
 - [Localization (i18n)](#localization-i18n)
 - [Bulk Embeddings API](#bulk-embeddings-api)
@@ -401,14 +403,21 @@ embeddingConfig: {
         query,
         documents: results.map((r) => r.chunkText),
       })
-      // Return VectorSearchResults in your desired order.
-      return ranked.map((r) => results[r.index])
+      return ranked
+        .map((r) => results[r.index])
+        .filter((r): r is (typeof results)[number] => r !== undefined)
     },
   },
 }
 ```
 
-The plugin trims the callback's output to the caller's `limit`. Errors thrown by the callback propagate to the caller. `multiplier` must be a finite number `>= 1`; invalid configs are rejected at plugin init. If `limit` is omitted, the rerank branch falls back to a default of `10` for fetch sizing.
+**Multiplier.** Use `1` when you only want reordering of the same candidate set. Use a higher value (3–5 is typical) when you also want to expand the candidate pool before reranking — higher = better recall, more latency, more cost.
+
+**Limit.** The plugin trims the callback's output to the caller's `limit`. If the callback returns fewer than `limit`, the smaller count is returned as-is. If `limit` is omitted, the rerank branch uses `10` for fetch sizing — note this differs from the non-rerank path, where an omitted `limit` is forwarded to the adapter and the adapter picks its own default.
+
+**Errors.** Errors thrown by the callback propagate to the caller — there is no silent fallback to unranked results.
+
+**Validation.** `multiplier` must be a finite number `>= 1` and `callback` must be a function; invalid configs are rejected at plugin init.
 
 ## Chunkers
 

--- a/dev/specs/rerankValidation.spec.ts
+++ b/dev/specs/rerankValidation.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+import { buildConfig } from 'payload'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { makeDummyEmbedDocs, makeDummyEmbedQuery, testEmbeddingVersion } from 'helpers/embed.js'
+import { createMockAdapter } from 'helpers/mockAdapter.js'
+import payloadcmsVectorize, { type RerankFn } from 'payloadcms-vectorize'
+import { DIMS } from './constants.js'
+
+const dbName = 'rerank_validation_test'
+
+const buildWithRerank = async (rerank: any) =>
+  buildConfig({
+    collections: [{ slug: 'posts', fields: [{ name: 'title', type: 'text' }] }],
+    db: postgresAdapter({
+      pool: {
+        connectionString: `postgresql://postgres:password@localhost:5433/${dbName}`,
+      },
+    }),
+    plugins: [
+      payloadcmsVectorize({
+        dbAdapter: createMockAdapter(),
+        knowledgePools: {
+          default: {
+            collections: {
+              posts: {
+                toKnowledgePool: async (doc) => (doc.title ? [{ chunk: doc.title }] : []),
+              },
+            },
+            embeddingConfig: {
+              version: testEmbeddingVersion,
+              queryFn: makeDummyEmbedQuery(DIMS),
+              realTimeIngestionFn: makeDummyEmbedDocs(DIMS),
+              rerank,
+            },
+          },
+        },
+      }),
+    ],
+    secret: 'rerank-validation-secret',
+    jobs: { tasks: [] },
+  })
+
+const validCallback: RerankFn = async (_q, r) => r
+
+describe('rerank config validation', () => {
+  test('multiplier = 0 throws', async () => {
+    await expect(buildWithRerank({ multiplier: 0, callback: validCallback })).rejects.toThrow(
+      /multiplier/i,
+    )
+  })
+
+  test('multiplier = -1 throws', async () => {
+    await expect(buildWithRerank({ multiplier: -1, callback: validCallback })).rejects.toThrow(
+      /multiplier/i,
+    )
+  })
+
+  test('multiplier = NaN throws', async () => {
+    await expect(buildWithRerank({ multiplier: NaN, callback: validCallback })).rejects.toThrow(
+      /multiplier/i,
+    )
+  })
+
+  test('multiplier = Infinity throws', async () => {
+    await expect(
+      buildWithRerank({ multiplier: Infinity, callback: validCallback }),
+    ).rejects.toThrow(/multiplier/i)
+  })
+
+  test('callback not a function throws', async () => {
+    await expect(buildWithRerank({ multiplier: 2, callback: 'nope' as any })).rejects.toThrow(
+      /callback/i,
+    )
+  })
+
+  test('valid config does not throw', async () => {
+    await expect(
+      buildWithRerank({ multiplier: 1.5, callback: validCallback }),
+    ).resolves.toBeTruthy()
+  })
+})

--- a/dev/specs/vectorSearchRerank.spec.ts
+++ b/dev/specs/vectorSearchRerank.spec.ts
@@ -1,0 +1,140 @@
+import type { Payload, BasePayload, Where } from 'payload'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { getPayload, buildConfig } from 'payload'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { makeDummyEmbedDocs, makeDummyEmbedQuery, testEmbeddingVersion } from 'helpers/embed.js'
+import { chunkText } from 'helpers/chunkers.js'
+import { createMockAdapter } from 'helpers/mockAdapter.js'
+import {
+  createTestDb,
+  destroyPayload,
+  waitForVectorizationJobs,
+} from './utils.js'
+import { DIMS } from './constants.js'
+import payloadcmsVectorize, {
+  type DbAdapter,
+  type KnowledgePoolDynamicConfig,
+  type RerankFn,
+  type VectorSearchResult,
+} from 'payloadcms-vectorize'
+import { createVectorSearchHandlers } from '../../src/endpoints/vectorSearch.js'
+
+const dbName = 'rerank_test'
+
+type AdapterCall = { limit: number | undefined }
+
+/** Wrap an adapter to record the limit passed to search(). */
+function wrapAdapter(adapter: DbAdapter): { adapter: DbAdapter; calls: AdapterCall[] } {
+  const calls: AdapterCall[] = []
+  const origSearch = adapter.search
+  const wrapped: DbAdapter = {
+    ...adapter,
+    search: async (
+      payload: BasePayload,
+      queryEmbedding: number[],
+      poolName: string,
+      limit?: number,
+      where?: Where,
+    ): Promise<VectorSearchResult[]> => {
+      calls.push({ limit })
+      return origSearch(payload, queryEmbedding, poolName, limit, where)
+    },
+  }
+  return { adapter: wrapped, calls }
+}
+
+function buildPools(rerank?: {
+  multiplier: number
+  callback: RerankFn
+}): Record<string, KnowledgePoolDynamicConfig> {
+  return {
+    default: {
+      collections: {
+        posts: {
+          toKnowledgePool: async (doc) => {
+            const chunks: Array<{ chunk: string }> = []
+            if (doc.title) chunks.push(...chunkText(doc.title).map((c) => ({ chunk: c })))
+            return chunks
+          },
+        },
+      },
+      embeddingConfig: {
+        version: testEmbeddingVersion,
+        queryFn: makeDummyEmbedQuery(DIMS),
+        realTimeIngestionFn: makeDummyEmbedDocs(DIMS),
+        ...(rerank ? { rerank } : {}),
+      },
+    },
+  }
+}
+
+describe('rerank callback', () => {
+  let payload: Payload
+  let baseAdapter: DbAdapter
+
+  beforeAll(async () => {
+    await createTestDb({ dbName })
+    baseAdapter = createMockAdapter()
+
+    const config = await buildConfig({
+      collections: [
+        {
+          slug: 'posts',
+          fields: [{ name: 'title', type: 'text' }],
+        },
+      ],
+      db: postgresAdapter({
+        pool: {
+          connectionString: `postgresql://postgres:password@localhost:5433/${dbName}`,
+        },
+      }),
+      plugins: [
+        payloadcmsVectorize({
+          dbAdapter: baseAdapter,
+          knowledgePools: buildPools(),
+        }),
+      ],
+      secret: 'rerank-test-secret',
+      jobs: { tasks: [] },
+    })
+
+    payload = await getPayload({
+      config,
+      key: `rerank-test-${Date.now()}`,
+      cron: false,
+    })
+
+    // Seed three posts so we have multiple results to reorder.
+    for (const title of ['alpha', 'bravo', 'charlie']) {
+      await payload.create({ collection: 'posts', data: { title } })
+    }
+    await waitForVectorizationJobs(payload)
+  })
+
+  afterAll(async () => {
+    await destroyPayload(payload)
+  })
+
+  test('callback is invoked and its order is preserved', async () => {
+    const callback = vi.fn(async (_query: string, results: VectorSearchResult[]) => {
+      // Reverse — proves the plugin honored the callback's order.
+      return [...results].reverse()
+    })
+
+    // Baseline: a separate handlers with NO rerank, so the callback only fires once total.
+    const baselinePools = buildPools()
+    const baselineAdapter = wrapAdapter(baseAdapter).adapter
+    const baselineHandlers = createVectorSearchHandlers(baselinePools, baselineAdapter)
+
+    const rerankPools = buildPools({ multiplier: 1, callback })
+    const { adapter: rerankAdapter } = wrapAdapter(baseAdapter)
+    const rerankHandlers = createVectorSearchHandlers(rerankPools, rerankAdapter)
+
+    const baseline = await baselineHandlers.vectorSearch(payload, 'alpha', 'default', 3)
+    const reranked = await rerankHandlers.vectorSearch(payload, 'alpha', 'default', 3)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback.mock.calls[0][0]).toBe('alpha')
+    expect(reranked.map((r) => r.id)).toEqual([...baseline.map((r) => r.id)].reverse())
+  })
+})

--- a/dev/specs/vectorSearchRerank.spec.ts
+++ b/dev/specs/vectorSearchRerank.spec.ts
@@ -170,6 +170,18 @@ describe('rerank callback', () => {
     expect(calls[0].limit).toBe(15)
   })
 
+  test('rerank with omitted limit: adapter receives multiplier * 10 (default)', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results)
+    const pools = buildPools({ multiplier: 2, callback })
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(20)
+  })
+
   test('no rerank configured: adapter receives the unmodified limit', async () => {
     const pools = buildPools()
     const { adapter, calls } = wrapAdapter(baseAdapter)

--- a/dev/specs/vectorSearchRerank.spec.ts
+++ b/dev/specs/vectorSearchRerank.spec.ts
@@ -172,4 +172,45 @@ describe('rerank callback', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0].limit).toBe(4)
   })
+
+  test('callback returning more than limit: plugin trims to limit', async () => {
+    const syntheticResults: VectorSearchResult[] = Array.from({ length: 5 }, (_, i) => ({
+      id: String(i),
+      score: 1 - i * 0.1,
+      sourceCollection: 'posts',
+      docId: String(i),
+      chunkIndex: i,
+      chunkText: `chunk ${i}`,
+      embeddingVersion: 'test-v1',
+    }))
+    const callback = vi.fn(async (_q: string, _results: VectorSearchResult[]) => syntheticResults)
+    const pools = buildPools({ multiplier: 3, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    const out = await handlers.vectorSearch(payload, 'alpha', 'default', 2)
+
+    // Callback returns 5 synthetic results; plugin slices to limit=2.
+    expect(out).toHaveLength(2)
+  })
+
+  test('callback returning fewer than limit: plugin returns the smaller count', async () => {
+    const syntheticResult: VectorSearchResult = {
+      id: '0',
+      score: 0.9,
+      sourceCollection: 'posts',
+      docId: '0',
+      chunkIndex: 0,
+      chunkText: 'chunk 0',
+      embeddingVersion: 'test-v1',
+    }
+    const callback = vi.fn(async (_q: string, _results: VectorSearchResult[]) => [syntheticResult])
+    const pools = buildPools({ multiplier: 3, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    const out = await handlers.vectorSearch(payload, 'alpha', 'default', 3)
+
+    expect(out).toHaveLength(1)
+  })
 })

--- a/dev/specs/vectorSearchRerank.spec.ts
+++ b/dev/specs/vectorSearchRerank.spec.ts
@@ -95,13 +95,21 @@ describe('rerank callback', () => {
         }),
       ],
       secret: 'rerank-test-secret',
-      jobs: { tasks: [] },
+      jobs: {
+        tasks: [],
+        autoRun: [
+          {
+            cron: '*/5 * * * * *',
+            limit: 10,
+          },
+        ],
+      },
     })
 
     payload = await getPayload({
       config,
       key: `rerank-test-${Date.now()}`,
-      cron: false,
+      cron: true,
     })
 
     // Seed three posts so we have multiple results to reorder.

--- a/dev/specs/vectorSearchRerank.spec.ts
+++ b/dev/specs/vectorSearchRerank.spec.ts
@@ -221,4 +221,17 @@ describe('rerank callback', () => {
 
     expect(out).toHaveLength(1)
   })
+
+  test('callback rejection propagates to the caller', async () => {
+    const callback = vi.fn(async () => {
+      throw new Error('reranker down')
+    })
+    const pools = buildPools({ multiplier: 2, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await expect(handlers.vectorSearch(payload, 'alpha', 'default', 2)).rejects.toThrow(
+      'reranker down',
+    )
+  })
 })

--- a/dev/specs/vectorSearchRerank.spec.ts
+++ b/dev/specs/vectorSearchRerank.spec.ts
@@ -137,4 +137,39 @@ describe('rerank callback', () => {
     expect(callback.mock.calls[0][0]).toBe('alpha')
     expect(reranked.map((r) => r.id)).toEqual([...baseline.map((r) => r.id)].reverse())
   })
+
+  test('multiplier=3 fetches limit*3 candidates from the adapter', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results)
+    const pools = buildPools({ multiplier: 3, callback })
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default', 2)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(6)
+  })
+
+  test('float multiplier=1.5 with limit=10 fetches 15 candidates (Math.floor)', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results)
+    const pools = buildPools({ multiplier: 1.5, callback })
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default', 10)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(15)
+  })
+
+  test('no rerank configured: adapter receives the unmodified limit', async () => {
+    const pools = buildPools()
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default', 4)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(4)
+  })
 })

--- a/docs/superpowers/plans/2026-05-18-rerank-callback.md
+++ b/docs/superpowers/plans/2026-05-18-rerank-callback.md
@@ -1,0 +1,707 @@
+# Rerank Callback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in per-knowledge-pool `rerank` callback to `payloadcms-vectorize`, letting users widen the candidate pool, reorder via their own reranker, then return the top `limit`.
+
+**Architecture:** A `RerankConfig` (`{ multiplier, callback }`) lives on each pool's `EmbeddingConfig`. The `vectorSearch` function fetches `Math.floor(limit * multiplier)` candidates from the adapter, passes them through the user callback, and trims to `limit`. No adapter changes. Errors propagate. Validation runs at plugin init.
+
+**Tech Stack:** TypeScript, Vitest, Payload CMS plugin runtime, Postgres test infra via existing `createMockAdapter`.
+
+**Spec:** [docs/superpowers/specs/2026-05-18-rerank-callback-design.md](../specs/2026-05-18-rerank-callback-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `src/types.ts` — add `RerankFn` and `RerankConfig` types; add optional `rerank` field on `EmbeddingConfig`.
+- **Modify** `src/endpoints/vectorSearch.ts` — wire rerank into the search pipeline.
+- **Modify** `src/index.ts` — validate `rerank` config inside the existing pool-iteration loop (around line 124).
+- **Create** `dev/specs/vectorSearchRerank.spec.ts` — full behavior coverage.
+- **Modify** `README.md` — add a "Reranking" section under the search docs.
+
+---
+
+## Task 1: Add types
+
+**Files:**
+- Modify: `src/types.ts:130-146` (extend `EmbeddingConfig`); insert new types just above it.
+
+- [ ] **Step 1: Add `RerankFn` and `RerankConfig` types**
+
+In `src/types.ts`, just before the `EmbeddingConfig` type declaration, add:
+
+```ts
+export type RerankFn = (
+  query: string,
+  results: VectorSearchResult[],
+) => Promise<VectorSearchResult[]>
+
+export type RerankConfig = {
+  /** DB fetches Math.floor(limit * multiplier) candidates before reranking.
+   *  Must be a finite number >= 1. */
+  multiplier: number
+  callback: RerankFn
+}
+```
+
+- [ ] **Step 2: Add optional `rerank` field on `EmbeddingConfig`**
+
+Inside the existing `EmbeddingConfig` type, add as the last field:
+
+```ts
+  /** Optional reranker. When set, the search pipeline fetches
+   *  Math.floor(limit * rerank.multiplier) candidates, passes them
+   *  to rerank.callback, then trims to the requested limit. */
+  rerank?: RerankConfig
+```
+
+- [ ] **Step 3: Verify type-only compile**
+
+Run: `pnpm tsc --noEmit -p tsconfig.json`
+Expected: PASS (no errors). If the repo uses a different typecheck command (e.g. `pnpm typecheck`), use that.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(types): add RerankFn and RerankConfig types"
+```
+
+---
+
+## Task 2: Test — rerank callback is called and reorders results
+
+**Files:**
+- Create: `dev/specs/vectorSearchRerank.spec.ts`
+
+This task uses TDD. The test will fail because the wiring doesn't exist yet — Task 3 implements the wiring.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `dev/specs/vectorSearchRerank.spec.ts`:
+
+```ts
+import type { Payload, BasePayload, Where } from 'payload'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { getPayload, buildConfig } from 'payload'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { makeDummyEmbedDocs, makeDummyEmbedQuery, testEmbeddingVersion } from 'helpers/embed.js'
+import { chunkText } from 'helpers/chunkers.js'
+import { createMockAdapter } from 'helpers/mockAdapter.js'
+import {
+  createTestDb,
+  destroyPayload,
+  waitForVectorizationJobs,
+} from './utils.js'
+import { DIMS } from './constants.js'
+import payloadcmsVectorize, {
+  type DbAdapter,
+  type KnowledgePoolDynamicConfig,
+  type RerankFn,
+  type VectorSearchResult,
+} from 'payloadcms-vectorize'
+import { createVectorSearchHandlers } from '../../src/endpoints/vectorSearch.js'
+
+const dbName = 'rerank_test'
+
+type AdapterCall = { limit: number | undefined }
+
+/** Wrap an adapter to record the limit passed to search(). */
+function wrapAdapter(adapter: DbAdapter): { adapter: DbAdapter; calls: AdapterCall[] } {
+  const calls: AdapterCall[] = []
+  const origSearch = adapter.search
+  const wrapped: DbAdapter = {
+    ...adapter,
+    search: async (
+      payload: BasePayload,
+      queryEmbedding: number[],
+      poolName: string,
+      limit?: number,
+      where?: Where,
+    ): Promise<VectorSearchResult[]> => {
+      calls.push({ limit })
+      return origSearch(payload, queryEmbedding, poolName, limit, where)
+    },
+  }
+  return { adapter: wrapped, calls }
+}
+
+function buildPools(rerank?: {
+  multiplier: number
+  callback: RerankFn
+}): Record<string, KnowledgePoolDynamicConfig> {
+  return {
+    default: {
+      collections: {
+        posts: {
+          toKnowledgePool: async (doc) => {
+            const chunks: Array<{ chunk: string }> = []
+            if (doc.title) chunks.push(...chunkText(doc.title).map((c) => ({ chunk: c })))
+            return chunks
+          },
+        },
+      },
+      embeddingConfig: {
+        version: testEmbeddingVersion,
+        queryFn: makeDummyEmbedQuery(DIMS),
+        realTimeIngestionFn: makeDummyEmbedDocs(DIMS),
+        ...(rerank ? { rerank } : {}),
+      },
+    },
+  }
+}
+
+describe('rerank callback', () => {
+  let payload: Payload
+  let baseAdapter: DbAdapter
+
+  beforeAll(async () => {
+    await createTestDb({ dbName })
+    baseAdapter = createMockAdapter()
+
+    const config = await buildConfig({
+      collections: [
+        {
+          slug: 'posts',
+          fields: [{ name: 'title', type: 'text' }],
+        },
+      ],
+      db: postgresAdapter({
+        pool: {
+          connectionString: `postgresql://postgres:password@localhost:5433/${dbName}`,
+        },
+      }),
+      plugins: [
+        payloadcmsVectorize({
+          dbAdapter: baseAdapter,
+          knowledgePools: buildPools(),
+        }),
+      ],
+      secret: 'rerank-test-secret',
+      jobs: { tasks: [] },
+    })
+
+    payload = await getPayload({
+      config,
+      key: `rerank-test-${Date.now()}`,
+      cron: false,
+    })
+
+    // Seed three posts so we have multiple results to reorder.
+    for (const title of ['alpha', 'bravo', 'charlie']) {
+      await payload.create({ collection: 'posts', data: { title } })
+    }
+    await waitForVectorizationJobs(payload)
+  })
+
+  afterAll(async () => {
+    await destroyPayload(payload)
+  })
+
+  test('callback is invoked and its order is preserved', async () => {
+    const callback = vi.fn(async (_query: string, results: VectorSearchResult[]) => {
+      // Reverse — proves the plugin honored the callback's order.
+      return [...results].reverse()
+    })
+    const pools = buildPools({ multiplier: 1, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    const baseline = await handlers.vectorSearch(payload, 'alpha', 'default', 3)
+    const reranked = await handlers.vectorSearch(payload, 'alpha', 'default', 3)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback.mock.calls[0][0]).toBe('alpha')
+    expect(reranked.map((r) => r.id)).toEqual([...baseline.map((r) => r.id)].reverse())
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
+Expected: FAIL — either a TypeScript error (`RerankFn` not exported) or the assertion fails because the callback is never called.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add dev/specs/vectorSearchRerank.spec.ts
+git commit -m "test(rerank): add failing test for callback invocation and ordering"
+```
+
+---
+
+## Task 3: Wire rerank into `vectorSearch`
+
+**Files:**
+- Modify: `src/endpoints/vectorSearch.ts:14-30`
+
+- [ ] **Step 1: Update `vectorSearch` to call the rerank callback**
+
+Replace the body of the `vectorSearch` function in `src/endpoints/vectorSearch.ts` with:
+
+```ts
+  const vectorSearch = async (
+    payload: BasePayload,
+    query: string,
+    knowledgePool: KnowledgePoolName,
+    limit?: number,
+    where?: Where,
+  ) => {
+    const poolConfig = knowledgePools[knowledgePool]
+    const queryEmbedding = await (async () => {
+      const qE = await poolConfig.embeddingConfig.queryFn(query)
+      return Array.isArray(qE) ? qE : Array.from(qE)
+    })()
+
+    const rerank = poolConfig.embeddingConfig.rerank
+    const effectiveLimit = limit ?? 10
+    const fetchLimit = rerank
+      ? Math.floor(effectiveLimit * rerank.multiplier)
+      : effectiveLimit
+
+    const candidates = await adapter.search(
+      payload,
+      queryEmbedding,
+      knowledgePool,
+      fetchLimit,
+      where,
+    )
+
+    if (!rerank) return candidates
+
+    const reranked = await rerank.callback(query, candidates)
+    return reranked.slice(0, effectiveLimit)
+  }
+```
+
+- [ ] **Step 2: Re-export the new types from the package root**
+
+In `src/index.ts`, find the `export type { ... } from './types.js'` block (starts around line 38). Inside it, find the `// EmbeddingConfig` comment marker and add `RerankFn` and `RerankConfig` underneath the existing `BulkEmbeddingsFns` line, so that block reads:
+
+```ts
+  // EmbeddingConfig
+  EmbedQueryFn,
+  EmbedDocsFn,
+  BulkEmbeddingsFns,
+  RerankFn,
+  RerankConfig,
+```
+
+- [ ] **Step 3: Run the test and verify it passes**
+
+Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
+Expected: PASS — the `'callback is invoked and its order is preserved'` test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/endpoints/vectorSearch.ts src/index.ts
+git commit -m "feat(rerank): wire rerank callback into vectorSearch pipeline"
+```
+
+---
+
+## Task 4: Test + verify multiplier expands fetch size
+
+**Files:**
+- Modify: `dev/specs/vectorSearchRerank.spec.ts`
+
+- [ ] **Step 1: Add tests for fetch-size expansion**
+
+Append inside the `describe('rerank callback', () => { ... })` block:
+
+```ts
+  test('multiplier=3 fetches limit*3 candidates from the adapter', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results)
+    const pools = buildPools({ multiplier: 3, callback })
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default', 2)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(6)
+  })
+
+  test('float multiplier=1.5 with limit=10 fetches 15 candidates (Math.floor)', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results)
+    const pools = buildPools({ multiplier: 1.5, callback })
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default', 10)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(15)
+  })
+
+  test('no rerank configured: adapter receives the unmodified limit', async () => {
+    const pools = buildPools()
+    const { adapter, calls } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await handlers.vectorSearch(payload, 'alpha', 'default', 4)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].limit).toBe(4)
+  })
+```
+
+- [ ] **Step 2: Run the tests and verify they pass**
+
+Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
+Expected: PASS (all four tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dev/specs/vectorSearchRerank.spec.ts
+git commit -m "test(rerank): verify multiplier expands adapter fetch size"
+```
+
+---
+
+## Task 5: Test trimming behaviors
+
+**Files:**
+- Modify: `dev/specs/vectorSearchRerank.spec.ts`
+
+- [ ] **Step 1: Add tests for trimming**
+
+Append to the `describe` block:
+
+```ts
+  test('callback returning more than limit: plugin trims to limit', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results)
+    const pools = buildPools({ multiplier: 3, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    const out = await handlers.vectorSearch(payload, 'alpha', 'default', 2)
+
+    // Callback receives up to 6 candidates and returns them all; plugin slices to 2.
+    expect(out).toHaveLength(2)
+  })
+
+  test('callback returning fewer than limit: plugin returns the smaller count', async () => {
+    const callback = vi.fn(async (_q: string, results: VectorSearchResult[]) => results.slice(0, 1))
+    const pools = buildPools({ multiplier: 3, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    const out = await handlers.vectorSearch(payload, 'alpha', 'default', 3)
+
+    expect(out).toHaveLength(1)
+  })
+```
+
+- [ ] **Step 2: Run the tests and verify they pass**
+
+Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dev/specs/vectorSearchRerank.spec.ts
+git commit -m "test(rerank): verify post-callback trimming to limit"
+```
+
+---
+
+## Task 6: Test error propagation
+
+**Files:**
+- Modify: `dev/specs/vectorSearchRerank.spec.ts`
+
+- [ ] **Step 1: Add error-propagation test**
+
+Append to the `describe` block:
+
+```ts
+  test('callback rejection propagates to the caller', async () => {
+    const callback = vi.fn(async () => {
+      throw new Error('reranker down')
+    })
+    const pools = buildPools({ multiplier: 2, callback })
+    const { adapter } = wrapAdapter(baseAdapter)
+    const handlers = createVectorSearchHandlers(pools, adapter)
+
+    await expect(handlers.vectorSearch(payload, 'alpha', 'default', 2)).rejects.toThrow(
+      'reranker down',
+    )
+  })
+```
+
+- [ ] **Step 2: Run the tests and verify it passes**
+
+Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
+Expected: PASS — the wiring in Task 3 awaits `rerank.callback(...)`, so a rejection naturally propagates.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dev/specs/vectorSearchRerank.spec.ts
+git commit -m "test(rerank): verify callback errors propagate"
+```
+
+---
+
+## Task 7: Init-time validation of `rerank` config
+
+**Files:**
+- Create: `dev/specs/rerankValidation.spec.ts`
+- Modify: `src/index.ts:124-135` (extend the existing per-pool loop)
+
+- [ ] **Step 1: Write failing validation tests**
+
+Create `dev/specs/rerankValidation.spec.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest'
+import { buildConfig } from 'payload'
+import { postgresAdapter } from '@payloadcms/db-postgres'
+import { makeDummyEmbedDocs, makeDummyEmbedQuery, testEmbeddingVersion } from 'helpers/embed.js'
+import { createMockAdapter } from 'helpers/mockAdapter.js'
+import payloadcmsVectorize, { type RerankFn } from 'payloadcms-vectorize'
+import { DIMS } from './constants.js'
+
+const dbName = 'rerank_validation_test'
+
+const buildWithRerank = async (rerank: any) =>
+  buildConfig({
+    collections: [{ slug: 'posts', fields: [{ name: 'title', type: 'text' }] }],
+    db: postgresAdapter({
+      pool: {
+        connectionString: `postgresql://postgres:password@localhost:5433/${dbName}`,
+      },
+    }),
+    plugins: [
+      payloadcmsVectorize({
+        dbAdapter: createMockAdapter(),
+        knowledgePools: {
+          default: {
+            collections: {
+              posts: {
+                toKnowledgePool: async (doc) => (doc.title ? [{ chunk: doc.title }] : []),
+              },
+            },
+            embeddingConfig: {
+              version: testEmbeddingVersion,
+              queryFn: makeDummyEmbedQuery(DIMS),
+              realTimeIngestionFn: makeDummyEmbedDocs(DIMS),
+              rerank,
+            },
+          },
+        },
+      }),
+    ],
+    secret: 'rerank-validation-secret',
+    jobs: { tasks: [] },
+  })
+
+const validCallback: RerankFn = async (_q, r) => r
+
+describe('rerank config validation', () => {
+  test('multiplier = 0 throws', async () => {
+    await expect(buildWithRerank({ multiplier: 0, callback: validCallback })).rejects.toThrow(
+      /multiplier/i,
+    )
+  })
+
+  test('multiplier = -1 throws', async () => {
+    await expect(buildWithRerank({ multiplier: -1, callback: validCallback })).rejects.toThrow(
+      /multiplier/i,
+    )
+  })
+
+  test('multiplier = NaN throws', async () => {
+    await expect(buildWithRerank({ multiplier: NaN, callback: validCallback })).rejects.toThrow(
+      /multiplier/i,
+    )
+  })
+
+  test('multiplier = Infinity throws', async () => {
+    await expect(
+      buildWithRerank({ multiplier: Infinity, callback: validCallback }),
+    ).rejects.toThrow(/multiplier/i)
+  })
+
+  test('callback not a function throws', async () => {
+    await expect(buildWithRerank({ multiplier: 2, callback: 'nope' as any })).rejects.toThrow(
+      /callback/i,
+    )
+  })
+
+  test('valid config does not throw', async () => {
+    await expect(
+      buildWithRerank({ multiplier: 1.5, callback: validCallback }),
+    ).resolves.toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `pnpm test dev/specs/rerankValidation.spec.ts`
+Expected: FAIL — the invalid-config cases resolve instead of throwing because no validation exists yet.
+
+- [ ] **Step 3: Add validation to plugin init**
+
+In `src/index.ts`, find the existing per-pool loop around line 124 (the loop that builds `collectionToPools`). Just before that loop's closing brace, add a validation block. The final loop should look like:
+
+```ts
+    for (const poolName in pluginOptions.knowledgePools) {
+      const dynamicConfig = pluginOptions.knowledgePools[poolName]
+
+      // Build reverse mapping for hooks
+      const collectionSlugs = Object.keys(dynamicConfig.collections)
+      for (const collectionSlug of collectionSlugs) {
+        if (!collectionToPools.has(collectionSlug)) {
+          collectionToPools.set(collectionSlug, [])
+        }
+        collectionToPools.get(collectionSlug)!.push({ pool: poolName, dynamic: dynamicConfig })
+      }
+
+      // Validate rerank config (if present)
+      const rerank = dynamicConfig.embeddingConfig.rerank
+      if (rerank !== undefined) {
+        if (
+          typeof rerank.multiplier !== 'number' ||
+          !Number.isFinite(rerank.multiplier) ||
+          rerank.multiplier < 1
+        ) {
+          throw new Error(
+            `[payloadcms-vectorize] Pool "${poolName}": rerank.multiplier must be a finite number >= 1 (got ${String(rerank.multiplier)}).`,
+          )
+        }
+        if (typeof rerank.callback !== 'function') {
+          throw new Error(
+            `[payloadcms-vectorize] Pool "${poolName}": rerank.callback must be a function.`,
+          )
+        }
+      }
+    }
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm test dev/specs/rerankValidation.spec.ts`
+Expected: PASS (all six tests).
+
+- [ ] **Step 5: Run the full spec to ensure nothing regressed**
+
+Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts dev/specs/rerankValidation.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.ts dev/specs/rerankValidation.spec.ts
+git commit -m "feat(rerank): validate rerank config at plugin init"
+```
+
+---
+
+## Task 8: Run full test suite and typecheck
+
+**Files:** none
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS (no regressions in other specs).
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm tsc --noEmit -p tsconfig.json` (or the repo's `pnpm typecheck` if it exists — check `package.json` scripts).
+Expected: PASS.
+
+- [ ] **Step 3: If anything fails, fix in place and commit**
+
+Diagnose any failure, fix the root cause (do not weaken tests), commit as `fix(rerank): <description>`.
+
+---
+
+## Task 9: README docs
+
+**Files:**
+- Modify: `README.md` — add a "Reranking" section beneath the existing search docs.
+
+- [ ] **Step 1: Add the docs section**
+
+Locate the search section in `README.md` (`grep -n "search" README.md`) and append a new subsection:
+
+````markdown
+### Reranking (optional)
+
+Pass a `rerank` config on a pool's `embeddingConfig` to reorder candidates with your own reranker (e.g. Voyage, Cohere, a local cross-encoder):
+
+```ts
+embeddingConfig: {
+  version: 'v1',
+  queryFn,
+  realTimeIngestionFn,
+  rerank: {
+    // DB fetches Math.floor(limit * multiplier) candidates before reranking.
+    // Higher multiplier = better recall, more latency, more cost.
+    multiplier: 4,
+    callback: async (query, results) => {
+      const ranked = await myReranker.rerank({
+        query,
+        documents: results.map((r) => r.chunkText),
+      })
+      // Return VectorSearchResults in your desired order.
+      return ranked.map((r) => results[r.index])
+    },
+  },
+}
+```
+
+The plugin trims the callback's output to the caller's `limit`. Errors thrown by the callback propagate to the caller.
+````
+
+- [ ] **Step 2: Verify markdown renders sensibly**
+
+Run: `grep -n "Reranking" README.md`
+Expected: matches the new heading.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(rerank): document RerankConfig usage in README"
+```
+
+---
+
+## Task 10: Changeset
+
+**Files:**
+- Create: `.changeset/<auto-named>.md`
+
+- [ ] **Step 1: Generate a changeset**
+
+Run: `pnpm changeset` and select `payloadcms-vectorize` with a `minor` bump (new feature, backwards compatible). Summary: `Add optional rerank callback on EmbeddingConfig for per-pool reranking.`
+
+If the repo has a non-interactive changeset convention (look at recent files in `.changeset/`), follow that pattern instead and create the file directly.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .changeset/
+git commit -m "chore(changeset): add minor bump for rerank callback feature"
+```
+
+---
+
+## Done
+
+All tasks complete when:
+- `pnpm test` passes
+- Typecheck passes
+- README has the Reranking section
+- A changeset is committed
+- New tests in `dev/specs/vectorSearchRerank.spec.ts` and `dev/specs/rerankValidation.spec.ts` cover: callback invocation, ordering, multiplier expansion (int + float), no-rerank baseline, trimming (over/under limit), error propagation, init validation (multiplier 0/-1/NaN/Infinity, non-function callback, valid config).

--- a/docs/superpowers/plans/2026-05-18-rerank-callback.md
+++ b/docs/superpowers/plans/2026-05-18-rerank-callback.md
@@ -56,16 +56,29 @@ Inside the existing `EmbeddingConfig` type, add as the last field:
   rerank?: RerankConfig
 ```
 
-- [ ] **Step 3: Verify type-only compile**
+- [ ] **Step 3: Re-export the new types from the package root**
+
+In `src/index.ts`, find the `export type { ... } from './types.js'` block (starts around line 38). Inside it, find the `// EmbeddingConfig` comment marker and add `RerankFn` and `RerankConfig` underneath the existing `BulkEmbeddingsFns` line, so that block reads:
+
+```ts
+  // EmbeddingConfig
+  EmbedQueryFn,
+  EmbedDocsFn,
+  BulkEmbeddingsFns,
+  RerankFn,
+  RerankConfig,
+```
+
+- [ ] **Step 4: Verify type-only compile**
 
 Run: `pnpm tsc --noEmit -p tsconfig.json`
 Expected: PASS (no errors). If the repo uses a different typecheck command (e.g. `pnpm typecheck`), use that.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/types.ts
-git commit -m "feat(types): add RerankFn and RerankConfig types"
+git add src/types.ts src/index.ts
+git commit -m "feat(types): add and re-export RerankFn and RerankConfig types"
 ```
 
 ---
@@ -204,12 +217,18 @@ describe('rerank callback', () => {
       // Reverse — proves the plugin honored the callback's order.
       return [...results].reverse()
     })
-    const pools = buildPools({ multiplier: 1, callback })
-    const { adapter } = wrapAdapter(baseAdapter)
-    const handlers = createVectorSearchHandlers(pools, adapter)
 
-    const baseline = await handlers.vectorSearch(payload, 'alpha', 'default', 3)
-    const reranked = await handlers.vectorSearch(payload, 'alpha', 'default', 3)
+    // Baseline: a separate handlers with NO rerank, so the callback only fires once total.
+    const baselinePools = buildPools()
+    const baselineAdapter = wrapAdapter(baseAdapter).adapter
+    const baselineHandlers = createVectorSearchHandlers(baselinePools, baselineAdapter)
+
+    const rerankPools = buildPools({ multiplier: 1, callback })
+    const { adapter: rerankAdapter } = wrapAdapter(baseAdapter)
+    const rerankHandlers = createVectorSearchHandlers(rerankPools, rerankAdapter)
+
+    const baseline = await baselineHandlers.vectorSearch(payload, 'alpha', 'default', 3)
+    const reranked = await rerankHandlers.vectorSearch(payload, 'alpha', 'default', 3)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback.mock.calls[0][0]).toBe('alpha')
@@ -221,7 +240,7 @@ describe('rerank callback', () => {
 - [ ] **Step 2: Run the test and verify it fails**
 
 Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
-Expected: FAIL — either a TypeScript error (`RerankFn` not exported) or the assertion fails because the callback is never called.
+Expected: FAIL on the assertion `expect(callback).toHaveBeenCalledTimes(1)` — the callback is never invoked because the wiring in `vectorSearch` doesn't exist yet. (Imports resolve because Task 1 already re-exports `RerankFn`.)
 
 - [ ] **Step 3: Commit the failing test**
 
@@ -256,10 +275,17 @@ Replace the body of the `vectorSearch` function in `src/endpoints/vectorSearch.t
     })()
 
     const rerank = poolConfig.embeddingConfig.rerank
+
+    // Non-rerank path: preserve existing behavior. Forward `limit` as-is
+    // (possibly undefined) so the adapter keeps deciding its own default.
+    if (!rerank) {
+      return adapter.search(payload, queryEmbedding, knowledgePool, limit, where)
+    }
+
+    // Rerank path: we must materialize a concrete fetch size, so apply the
+    // default of 10 only here.
     const effectiveLimit = limit ?? 10
-    const fetchLimit = rerank
-      ? Math.floor(effectiveLimit * rerank.multiplier)
-      : effectiveLimit
+    const fetchLimit = Math.floor(effectiveLimit * rerank.multiplier)
 
     const candidates = await adapter.search(
       payload,
@@ -269,35 +295,20 @@ Replace the body of the `vectorSearch` function in `src/endpoints/vectorSearch.t
       where,
     )
 
-    if (!rerank) return candidates
-
     const reranked = await rerank.callback(query, candidates)
     return reranked.slice(0, effectiveLimit)
   }
 ```
 
-- [ ] **Step 2: Re-export the new types from the package root**
-
-In `src/index.ts`, find the `export type { ... } from './types.js'` block (starts around line 38). Inside it, find the `// EmbeddingConfig` comment marker and add `RerankFn` and `RerankConfig` underneath the existing `BulkEmbeddingsFns` line, so that block reads:
-
-```ts
-  // EmbeddingConfig
-  EmbedQueryFn,
-  EmbedDocsFn,
-  BulkEmbeddingsFns,
-  RerankFn,
-  RerankConfig,
-```
-
-- [ ] **Step 3: Run the test and verify it passes**
+- [ ] **Step 2: Run the test and verify it passes**
 
 Run: `pnpm test dev/specs/vectorSearchRerank.spec.ts`
 Expected: PASS — the `'callback is invoked and its order is preserved'` test passes.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
-git add src/endpoints/vectorSearch.ts src/index.ts
+git add src/endpoints/vectorSearch.ts
 git commit -m "feat(rerank): wire rerank callback into vectorSearch pipeline"
 ```
 

--- a/docs/superpowers/specs/2026-05-18-rerank-callback-design.md
+++ b/docs/superpowers/specs/2026-05-18-rerank-callback-design.md
@@ -1,0 +1,123 @@
+# Rerank Callback — Design Spec
+
+**Date:** 2026-05-18
+**Status:** Approved for planning
+**Scope:** `payloadcms-vectorize` core plugin (no adapter changes)
+
+## Goal
+
+Let users plug a reranker into vector search without coupling the plugin to any specific reranking provider. The plugin runs the vector search, hands the candidates to the user's callback, and returns the reordered top results.
+
+## Non-goals
+
+- Shipping a provider-specific reranker (Voyage, Cohere, etc.). Users wire their own.
+- Per-query reranker selection. A single reranker per knowledge pool.
+- Streaming or partial results.
+
+## API
+
+### Type additions (`src/types.ts`)
+
+```ts
+export type RerankFn = (
+  query: string,
+  results: VectorSearchResult[],
+) => Promise<VectorSearchResult[]>
+
+export type RerankConfig = {
+  /** DB fetches Math.floor(limit * multiplier) candidates before reranking.
+   *  Must be a finite number >= 1. */
+  multiplier: number
+  callback: RerankFn
+}
+```
+
+`EmbeddingConfig` gains an optional field:
+
+```ts
+export type EmbeddingConfig = {
+  // ...existing fields
+  rerank?: RerankConfig
+}
+```
+
+`rerank` lives per-knowledge-pool inside `EmbeddingConfig`, alongside `queryFn` and `version`. Different pools can have different rerankers (or none).
+
+### Caller-facing behavior
+
+`VectorSearchQuery` is unchanged. `limit` still means "results returned to the caller" (default 10). Reranking is invisible to callers other than through ordering.
+
+## Search pipeline
+
+Implemented in `src/endpoints/vectorSearch.ts` inside the existing `vectorSearch` function.
+
+1. Resolve `rerank = poolConfig.embeddingConfig.rerank`.
+2. Compute fetch size:
+   - If `rerank`: `fetchLimit = Math.floor(limit * rerank.multiplier)`.
+   - Else: `fetchLimit = limit`.
+3. Call `adapter.search(payload, queryEmbedding, knowledgePool, fetchLimit, where)`.
+4. If `rerank`: `const reranked = await rerank.callback(query, results); return reranked.slice(0, limit)`.
+5. Else: return adapter results as-is.
+
+`where` is applied at the DB layer before the reranker sees anything. The reranker only operates on already-filtered candidates.
+
+The `DbAdapter.search` interface is unchanged. Adapters do not know reranking exists; they just receive a larger `limit` when reranking is configured.
+
+## Validation
+
+At plugin initialization, for each pool with `rerank` configured, assert:
+
+- `typeof multiplier === 'number'`
+- `Number.isFinite(multiplier)`
+- `multiplier >= 1`
+- `typeof callback === 'function'`
+
+Failures throw with a message identifying the offending pool. This runs alongside existing pool-config validation.
+
+## Error handling
+
+If the callback throws or rejects, the error propagates to the caller. No silent fallback to unranked results — a silent fallback would mask reranker outages and produce confusing relevance regressions.
+
+## Output handling
+
+The plugin trims the callback's result to `limit` after it returns. Callbacks may return:
+
+- Exactly `limit` results — returned as-is.
+- More than `limit` (e.g. all `fetchLimit` candidates re-ordered) — plugin slices to `limit`.
+- Fewer than `limit` (e.g. callback dropped low-confidence items) — plugin returns the smaller count.
+
+The callback is trusted to return `VectorSearchResult` shapes. The plugin does not reconstruct or revalidate results.
+
+## Testing
+
+New spec file `dev/specs/vectorSearchRerank.spec.ts`:
+
+1. **No rerank configured** — existing behavior. Adapter receives the user's `limit`; results returned in cosine order.
+2. **Rerank configured, integer multiplier** — adapter receives `limit * multiplier`. Use a spy/wrapper around the adapter to assert the fetch size.
+3. **Rerank configured, float multiplier (1.5, limit=10)** — adapter receives `15`.
+4. **Callback reorders** — callback reverses results; returned order reflects the reversal.
+5. **Callback returns more than `limit`** — plugin trims to `limit`.
+6. **Callback returns fewer than `limit`** — plugin returns the smaller count.
+7. **Callback throws** — error propagates from `search()` to caller.
+8. **Invalid multiplier at init** — `0`, `-1`, `NaN`, `Infinity` each throw at plugin init.
+9. **Missing callback at init** — throws.
+
+Tests follow the existing pattern in `dev/specs/vectorSearchWhere.spec.ts` (real Postgres, real fixtures).
+
+## Docs
+
+Add a "Reranking" section to the plugin README under the search docs:
+
+- Shape of `RerankConfig`.
+- One worked example using Voyage's rerank API (illustrative, not bundled).
+- Note that `multiplier` controls the latency/recall tradeoff.
+
+## Files touched
+
+- `src/types.ts` — add `RerankFn`, `RerankConfig`; extend `EmbeddingConfig`.
+- `src/endpoints/vectorSearch.ts` — wire rerank into the search function.
+- `src/index.ts` — add multiplier/callback validation in the existing pool-config validation path.
+- `dev/specs/vectorSearchRerank.spec.ts` — new test file.
+- `README.md` — docs section.
+
+No adapter changes (PG or MongoDB).

--- a/src/endpoints/vectorSearch.ts
+++ b/src/endpoints/vectorSearch.ts
@@ -26,14 +26,10 @@ export const createVectorSearchHandlers = (
 
     const rerank = poolConfig.embeddingConfig.rerank
 
-    // Non-rerank path: preserve existing behavior. Forward `limit` as-is
-    // (possibly undefined) so the adapter keeps deciding its own default.
     if (!rerank) {
       return adapter.search(payload, queryEmbedding, knowledgePool, limit, where)
     }
 
-    // Rerank path: we must materialize a concrete fetch size, so apply the
-    // default of 10 only here.
     const effectiveLimit = limit ?? 10
     const fetchLimit = Math.floor(effectiveLimit * rerank.multiplier)
 

--- a/src/endpoints/vectorSearch.ts
+++ b/src/endpoints/vectorSearch.ts
@@ -19,14 +19,34 @@ export const createVectorSearchHandlers = (
     where?: Where,
   ) => {
     const poolConfig = knowledgePools[knowledgePool]
-    // Generate embedding for the query using pool-specific embedQuery
     const queryEmbedding = await (async () => {
       const qE = await poolConfig.embeddingConfig.queryFn(query)
       return Array.isArray(qE) ? qE : Array.from(qE)
     })()
 
-    // Perform cosine similarity search using Drizzle
-    return await adapter.search(payload, queryEmbedding, knowledgePool, limit, where)
+    const rerank = poolConfig.embeddingConfig.rerank
+
+    // Non-rerank path: preserve existing behavior. Forward `limit` as-is
+    // (possibly undefined) so the adapter keeps deciding its own default.
+    if (!rerank) {
+      return adapter.search(payload, queryEmbedding, knowledgePool, limit, where)
+    }
+
+    // Rerank path: we must materialize a concrete fetch size, so apply the
+    // default of 10 only here.
+    const effectiveLimit = limit ?? 10
+    const fetchLimit = Math.floor(effectiveLimit * rerank.multiplier)
+
+    const candidates = await adapter.search(
+      payload,
+      queryEmbedding,
+      knowledgePool,
+      fetchLimit,
+      where,
+    )
+
+    const reranked = await rerank.callback(query, candidates)
+    return reranked.slice(0, effectiveLimit)
   }
   const requestHandler: PayloadHandler = async (req) => {
     if (!req || !req.json) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ export type {
   EmbedQueryFn,
   EmbedDocsFn,
   BulkEmbeddingsFns,
+  RerankFn,
+  RerankConfig,
 
   // BulkEmbeddingsFns
   AddChunkArgs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,24 @@ export default (pluginOptions: PayloadcmsVectorizeConfig) =>
         }
         collectionToPools.get(collectionSlug)!.push({ pool: poolName, dynamic: dynamicConfig })
       }
+
+      const rerank = dynamicConfig.embeddingConfig.rerank
+      if (rerank !== undefined) {
+        if (
+          typeof rerank.multiplier !== 'number' ||
+          !Number.isFinite(rerank.multiplier) ||
+          rerank.multiplier < 1
+        ) {
+          throw new Error(
+            `[payloadcms-vectorize] Pool "${poolName}": rerank.multiplier must be a finite number >= 1 (got ${String(rerank.multiplier)}).`,
+          )
+        }
+        if (typeof rerank.callback !== 'function') {
+          throw new Error(
+            `[payloadcms-vectorize] Pool "${poolName}": rerank.callback must be a function.`,
+          )
+        }
+      }
     }
 
     // Validate bulk queue requirements

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export type RerankConfig = {
   /** DB fetches Math.floor(limit * multiplier) candidates before reranking.
    *  Must be a finite number >= 1. */
   multiplier: number
+  /** Receives the raw candidates and returns them in preferred order. */
   callback: RerankFn
 }
 
@@ -150,11 +151,11 @@ export type EmbeddingConfig = {
    * If not provided, then there is no real-time ingestion of documents provided by the user
    */
   realTimeIngestionFn?: EmbedDocsFn
-  /** Bulk embedding configuration provided by the user
-   * If not provided, then there bulk embedding is not available
-   */
+  /** Bulk embedding configuration provided by the user.
+   *  If not provided, then bulk embedding is not available.
+   *  If both realTimeIngestionFn and bulkEmbeddingsFns are not provided,
+   *  then embedding for this knowledge pool is essentially disabled. */
   bulkEmbeddingsFns?: BulkEmbeddingsFns
-  /** If both realTimeIngestionFn and bulkEmbeddingsConfig are not provided, then embedding for this knowledge pool is essentially disabled */
   /** Optional reranker. When set, the search pipeline fetches
    *  Math.floor(limit * rerank.multiplier) candidates, passes them
    *  to rerank.callback, then trims to the requested limit. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,18 @@ export type KnowledgePoolDynamicConfig = {
   embeddingConfig: EmbeddingConfig
 }
 
+export type RerankFn = (
+  query: string,
+  results: VectorSearchResult[],
+) => Promise<VectorSearchResult[]>
+
+export type RerankConfig = {
+  /** DB fetches Math.floor(limit * multiplier) candidates before reranking.
+   *  Must be a finite number >= 1. */
+  multiplier: number
+  callback: RerankFn
+}
+
 export type EmbeddingConfig = {
   /** Version string to track embedding model/version - stored in each embedding document */
   version: string
@@ -143,6 +155,10 @@ export type EmbeddingConfig = {
    */
   bulkEmbeddingsFns?: BulkEmbeddingsFns
   /** If both realTimeIngestionFn and bulkEmbeddingsConfig are not provided, then embedding for this knowledge pool is essentially disabled */
+  /** Optional reranker. When set, the search pipeline fetches
+   *  Math.floor(limit * rerank.multiplier) candidates, passes them
+   *  to rerank.callback, then trims to the requested limit. */
+  rerank?: RerankConfig
 }
 
 export type BulkEmbeddingRunStatus =


### PR DESCRIPTION
## Summary
- Adds optional `rerank: { multiplier, callback }` on each pool's `embeddingConfig`. When set, the plugin fetches `Math.floor(limit * multiplier)` candidates from the adapter, hands them to the user-supplied callback, and trims the callback's output to the caller's `limit`. Provider-agnostic — bring your own Voyage / Cohere / local cross-encoder.
- Non-rerank path is unchanged: `limit` is forwarded to the adapter as-is (possibly `undefined`), preserving existing direct payload-API caller behavior. The `?? 10` default only applies inside the rerank branch.
- `multiplier` must be a finite number `>= 1` (floats allowed, `Math.floor` applied). Invalid configs are rejected at plugin init with a pool-named error. Callback errors propagate to the caller — no silent fallback.
- Minor bump across all four fixed packages via changeset.

## Test plan
- [x] `pnpm test:int dev/specs/vectorSearchRerank.spec.ts` — 8 tests: callback invocation + ordering, multiplier (int and float) expanding fetch, `limit` omitted defaults to 10, no-rerank baseline, trim when callback returns more than limit, return-fewer when callback returns fewer, error propagation.
- [x] `pnpm test:int dev/specs/rerankValidation.spec.ts` — 6 tests: multiplier 0 / -1 / NaN / Infinity / non-function callback all throw; valid config builds cleanly.
- [x] `pnpm test:int` — full integration suite, 29 files / 81 tests passing.
- [x] `pnpm build:types` — typecheck clean.