### PR TITLE
chore: post-1.0 doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 A Payload CMS plugin that adds vector search capabilities to your collections. Perfect for building RAG (Retrieval-Augmented Generation) applications and semantic search features.
 
-> **Status:** `0.x` — pre-1.0. The public API is stabilizing but may still have breaking changes between minor releases. Track the [CHANGELOG](./CHANGELOG.md) before upgrading.
-
 ## Features
 
 - 🔍 [**Semantic Search**](#4-search-your-content) — vectorize any collection for intelligent content discovery.

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,9 +143,7 @@ export type RerankConfig = {
 export type EmbeddingConfig = {
   /** Version string to track embedding model/version - stored in each embedding document */
   version: string
-  /** Embedding function for query provided by the user
-   * TODO(techiejd): Should be optional? Maybe if not provided then we can disable the search endpoint?
-   */
+  /** Embedding function for query provided by the user */
   queryFn: EmbedQueryFn
   /** Embedding function for real-time ingestion of documents provided by the user
    * If not provided, then there is no real-time ingestion of documents provided by the user


### PR DESCRIPTION
Small cleanup now that 1.0.0 is out.

- Remove the `0.x — pre-1.0` status note from the README (no longer accurate).
- Drop the leftover `TODO(techiejd): Should be optional?` from `EmbeddingConfig.queryFn`'s JSDoc so it doesn't ship in the published `.d.ts`.

Docs/comments only — no code or API behavior changes. No changeset (not worth a release on its own; the README update on GitHub is the point).