### PR TITLE
refactor(cf): adopt @cloudflare/workers-types

### DIFF
--- a/adapters/cf/package.json
+++ b/adapters/cf/package.json
@@ -30,6 +30,7 @@
     "payloadcms-vectorize": ">=1.0.0"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240000.0",
     "payloadcms-vectorize": "workspace:*"
   },
   "engines": {

--- a/adapters/cf/src/index.ts
+++ b/adapters/cf/src/index.ts
@@ -1,7 +1,7 @@
 import type { CollectionSlug } from 'payload'
 import type { DbAdapter } from 'payloadcms-vectorize'
 import { getVectorizeBinding } from './types.js'
-import type { CloudflareVectorizeBinding, KnowledgePoolsConfig } from './types.js'
+import type { CloudflareVectorizeBinding, KnowledgePoolsConfig, VectorizeBinding } from './types.js'
 import cfMappingsCollection, { CF_MAPPINGS_SLUG } from './collections/cfMappings.js'
 import embed from './embed.js'
 import search from './search.js'
@@ -13,7 +13,7 @@ interface CloudflareVectorizeConfig {
   /** Knowledge pools configuration with their dimensions */
   config: KnowledgePoolsConfig
   /** Cloudflare Vectorize binding for vector storage */
-  binding: CloudflareVectorizeBinding
+  binding: VectorizeBinding
 }
 
 /**
@@ -134,5 +134,5 @@ export const createCloudflareVectorizeIntegration = (
 }
 
 export { CF_MAPPINGS_SLUG } from './collections/cfMappings.js'
-export type { CloudflareVectorizeBinding, KnowledgePoolsConfig }
+export type { CloudflareVectorizeBinding, KnowledgePoolsConfig, VectorizeBinding }
 export type { KnowledgePoolsConfig as KnowledgePoolConfig }

--- a/adapters/cf/src/types.ts
+++ b/adapters/cf/src/types.ts
@@ -1,65 +1,21 @@
+/// <reference types="@cloudflare/workers-types" />
 import type { BasePayload } from 'payload'
 import { getVectorizedPayload } from 'payloadcms-vectorize'
 
-/**
- * Retrieve the Cloudflare Vectorize binding from a Payload instance.
- * Throws if the binding is not found.
- */
-export function getVectorizeBinding(payload: BasePayload): CloudflareVectorizeBinding {
+export function getVectorizeBinding(payload: BasePayload): Vectorize {
   const binding = getVectorizedPayload(payload)?.getDbAdapterCustom()
-    ?._vectorizeBinding as CloudflareVectorizeBinding | undefined
+    ?._vectorizeBinding as Vectorize | undefined
   if (!binding) {
     throw new Error('[@payloadcms-vectorize/cf] Cloudflare Vectorize binding not found')
   }
   return binding
 }
 
-/**
- * Configuration for a knowledge pool in Cloudflare Vectorize
- */
 export interface CloudflareVectorizePoolConfig {
-  /** Vector dimensions for this pool (must match embedding model output) */
   dims: number
 }
 
-/**
- * All knowledge pools configuration for Cloudflare Vectorize
- */
 export type KnowledgePoolsConfig = Record<string, CloudflareVectorizePoolConfig>
 
-/** A single vector match returned by a Vectorize query */
-export interface VectorizeMatch {
-  id: string
-  score?: number
-  metadata?: Record<string, unknown>
-}
-
-/** Result of a Vectorize query */
-export interface VectorizeQueryResult {
-  matches: VectorizeMatch[]
-  count: number
-}
-
-/** Vector to upsert into Vectorize */
-export interface VectorizeVector {
-  id: string
-  values: number[]
-  metadata?: Record<string, unknown>
-}
-
-/**
- * Cloudflare Vectorize binding interface.
- * Mirrors the subset of the Vectorize API we use.
- * For the full type, install `@cloudflare/workers-types`.
- */
-export interface CloudflareVectorizeBinding {
-  query(vector: number[], options?: {
-    topK?: number
-    returnMetadata?: boolean | 'indexed' | 'all'
-    filter?: Record<string, unknown>
-    /** Vectorize metadata filtering */
-    where?: Record<string, unknown>
-  }): Promise<VectorizeQueryResult>
-  upsert(vectors: VectorizeVector[]): Promise<unknown>
-  deleteByIds(ids: string[]): Promise<unknown>
-}
+/** @deprecated Use the official `Vectorize` type from `@cloudflare/workers-types`. */
+export type CloudflareVectorizeBinding = Vectorize

--- a/adapters/cf/src/types.ts
+++ b/adapters/cf/src/types.ts
@@ -2,6 +2,10 @@
 import type { BasePayload } from 'payload'
 import { getVectorizedPayload } from 'payloadcms-vectorize'
 
+/**
+ * Retrieve the Cloudflare Vectorize binding from a Payload instance.
+ * Throws if the binding is not found.
+ */
 export function getVectorizeBinding(payload: BasePayload): Vectorize {
   const binding = getVectorizedPayload(payload)?.getDbAdapterCustom()
     ?._vectorizeBinding as Vectorize | undefined
@@ -11,10 +15,17 @@ export function getVectorizeBinding(payload: BasePayload): Vectorize {
   return binding
 }
 
+/**
+ * Configuration for a knowledge pool in Cloudflare Vectorize
+ */
 export interface CloudflareVectorizePoolConfig {
+  /** Vector dimensions for this pool (must match embedding model output) */
   dims: number
 }
 
+/**
+ * All knowledge pools configuration for Cloudflare Vectorize
+ */
 export type KnowledgePoolsConfig = Record<string, CloudflareVectorizePoolConfig>
 
 /** @deprecated Use the official `Vectorize` type from `@cloudflare/workers-types`. */

--- a/adapters/cf/src/types.ts
+++ b/adapters/cf/src/types.ts
@@ -3,12 +3,17 @@ import type { BasePayload } from 'payload'
 import { getVectorizedPayload } from 'payloadcms-vectorize'
 
 /**
+ * The subset of the Cloudflare `Vectorize` binding used by this adapter.
+ */
+export type VectorizeBinding = Pick<Vectorize, 'query' | 'upsert' | 'deleteByIds' | 'getByIds'>
+
+/**
  * Retrieve the Cloudflare Vectorize binding from a Payload instance.
  * Throws if the binding is not found.
  */
-export function getVectorizeBinding(payload: BasePayload): Vectorize {
+export function getVectorizeBinding(payload: BasePayload): VectorizeBinding {
   const binding = getVectorizedPayload(payload)?.getDbAdapterCustom()
-    ?._vectorizeBinding as Vectorize | undefined
+    ?._vectorizeBinding as VectorizeBinding | undefined
   if (!binding) {
     throw new Error('[@payloadcms-vectorize/cf] Cloudflare Vectorize binding not found')
   }
@@ -28,5 +33,5 @@ export interface CloudflareVectorizePoolConfig {
  */
 export type KnowledgePoolsConfig = Record<string, CloudflareVectorizePoolConfig>
 
-/** @deprecated Use the official `Vectorize` type from `@cloudflare/workers-types`. */
-export type CloudflareVectorizeBinding = Vectorize
+/** @deprecated Use {@link VectorizeBinding}. */
+export type CloudflareVectorizeBinding = VectorizeBinding

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: 3.3.3
       '@payloadcms/db-postgres':
         specifier: 3.69.0
-        version: 3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))
+        version: 3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))
       '@payloadcms/db-sqlite':
         specifier: 3.69.0
-        version: 3.69.0(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)
+        version: 3.69.0(@cloudflare/workers-types@4.20260531.1)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)
       '@payloadcms/eslint-config':
         specifier: 3.9.0
         version: 3.9.0(@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.7.3))(jest@30.2.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12)))(jiti@2.6.1)
@@ -153,6 +153,9 @@ importers:
         specifier: '>=3.0.0 <4.0.0'
         version: 3.69.0(graphql@16.12.0)(typescript@5.7.3)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20240000.0
+        version: 4.20260531.1
       payloadcms-vectorize:
         specifier: workspace:*
         version: link:../..
@@ -180,7 +183,7 @@ importers:
     dependencies:
       '@payloadcms/db-postgres':
         specifier: '>=3.0.0 <4.0.0'
-        version: 3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))
+        version: 3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))
       payload:
         specifier: '>=3.0.0 <4.0.0'
         version: 3.69.0(graphql@16.12.0)(typescript@5.7.3)
@@ -456,6 +459,9 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@cloudflare/workers-types@4.20260531.1':
+    resolution: {integrity: sha512-7DybhbX12n+mVgJEDvm9W/jjqpaUIczg+RWj1Hua9nGEG+pNJnT+yZj1JKENrbdyuGWx3OFEgUCNFcGJN86Dvg==}
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
@@ -7225,6 +7231,8 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@cloudflare/workers-types@4.20260531.1': {}
+
   '@date-fns/tz@1.2.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
@@ -8649,13 +8657,13 @@ snapshots:
       - socks
       - supports-color
 
-  '@payloadcms/db-postgres@3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))':
+  '@payloadcms/db-postgres@3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))':
     dependencies:
-      '@payloadcms/drizzle': 3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)
+      '@payloadcms/drizzle': 3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)
       '@types/pg': 8.10.2
       console-table-printer: 2.12.1
       drizzle-kit: 0.31.7
-      drizzle-orm: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(pg@8.16.3)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(pg@8.16.3)
       payload: 3.69.0(graphql@16.12.0)(typescript@5.7.3)
       pg: 8.16.3
       prompts: 2.4.2
@@ -8692,13 +8700,13 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@payloadcms/db-sqlite@3.69.0(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)':
+  '@payloadcms/db-sqlite@3.69.0(@cloudflare/workers-types@4.20260531.1)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)':
     dependencies:
       '@libsql/client': 0.14.0
-      '@payloadcms/drizzle': 3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)
+      '@payloadcms/drizzle': 3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)
       console-table-printer: 2.12.1
       drizzle-kit: 0.31.7
-      drizzle-orm: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3)
       payload: 3.69.0(graphql@16.12.0)(typescript@5.7.3)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -8736,11 +8744,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@payloadcms/drizzle@3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)':
+  '@payloadcms/drizzle@3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)':
     dependencies:
       console-table-printer: 2.12.1
       dequal: 2.0.3
-      drizzle-orm: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(pg@8.16.3)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(pg@8.16.3)
       payload: 3.69.0(graphql@16.12.0)(typescript@5.7.3)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -8776,11 +8784,11 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@payloadcms/drizzle@3.69.0(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)':
+  '@payloadcms/drizzle@3.69.0(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(payload@3.69.0(graphql@16.12.0)(typescript@5.7.3))(pg@8.16.3)':
     dependencies:
       console-table-printer: 2.12.1
       dequal: 2.0.3
-      drizzle-orm: 0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3)
+      drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3)
       payload: 3.69.0(graphql@16.12.0)(typescript@5.7.3)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -10671,15 +10679,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(pg@8.16.3):
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(pg@8.16.3):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260531.1
       '@libsql/client': 0.14.0
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.10.2
       pg: 8.16.3
 
-  drizzle-orm@0.44.7(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3):
+  drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260531.1)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260531.1
       '@libsql/client': 0.14.0
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.16.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
       }
     ]
   },
-  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./adapters/*/src/**/*.ts", "./dev/next-env.d.ts"]
+  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./dev/next-env.d.ts"]
 }


### PR DESCRIPTION
Swaps the hand-rolled Vectorize binding types for the official `@cloudflare/workers-types` package.

- Adds `@cloudflare/workers-types` as a devDependency.
- Deletes hand-rolled `VectorizeMatch`, `VectorizeQueryResult`, `VectorizeVector`, and the `CloudflareVectorizeBinding` interface; `getVectorizeBinding` now returns the official global `Vectorize` type (which exposes `getByIds`).
- Keeps a back-compat alias `export type CloudflareVectorizeBinding = Vectorize` so the published export name is unchanged.
- Pulls the ambient globals via a triple-slash reference in `types.ts` (no `compilerOptions.types` narrowing — `tsconfig.build.json` stays in parity with the pg/mongodb adapters).

No behavior change. Full CF suite green (90 tests) with zero test edits.

Prerequisite for `findEmbeddingsByIds` — unlocks the typed `getByIds` used by the upcoming CF `findByIds`.