### PR TITLE
chore: changeset for unreleased read primitives (minor → 1.1.0)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,5 +11,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": []
 }

--- a/.changeset/read-primitives-and-populate-embedding.md
+++ b/.changeset/read-primitives-and-populate-embedding.md
@@ -1,0 +1,16 @@
+---
+"payloadcms-vectorize": minor
+"@payloadcms-vectorize/pg": minor
+"@payloadcms-vectorize/cf": minor
+"@payloadcms-vectorize/mongodb": minor
+---
+
+Add vector read primitives and the ability to retrieve stored embedding vectors.
+
+- **`vectorizedPayload.findByIds({ knowledgePool, ids, populateEmbedding })`** — batch-fetch embedding records by id, returning `Record<string, EmbeddingRecord | undefined>` (misses map to `undefined`). Implemented across the pg, cf, and mongodb adapters.
+- **`vectorizedPayload.searchByEmbedding({ knowledgePool, embedding, where, limit, populateEmbedding })`** — run a vector search directly from a raw embedding vector, skipping the query-embedding step. This is the "more like this" primitive: feed it the `embedding` returned by `findByIds({ populateEmbedding: true })` to find similar content. Result shape and `where` filtering match `search()`. Unlike `search()`, it does not run reranking even on a pool configured with `rerank`, since rerankers operate on the original query text. Local API only.
+- **`populateEmbedding?: boolean`** option (default `false`) on `search()` and `searchByEmbedding()` — when `true`, each result includes its stored embedding vector. `VectorSearchResult` and `EmbeddingRecord` now expose `embedding?: number[]`.
+
+Fix:
+
+- **mongodb adapter** `search()` now returns all stored fields (including extension fields) on each result, matching the pg and cf adapters for cross-adapter parity.


### PR DESCRIPTION
## What

Adds the consolidated changeset for everything merged since `1.0.1`, plus the changeset-config fix that keeps the release a **minor** (`1.1.0`) instead of a major.

`changeset status` confirms all four packages bump to **1.1.0**:

```
payloadcms-vectorize          1.1.0
@payloadcms-vectorize/pg      1.1.0
@payloadcms-vectorize/cf      1.1.0
@payloadcms-vectorize/mongodb 1.1.0
```

## Why one changeset

Per the plan to ship one minor changeset covering the stacked PRs rather than one per PR. The unreleased, changeset-less PRs since `1.0.1` are:

- **#62** `findByIds` read primitive (feat)
- **#63** mongodb: return all stored fields from `search()` — CF/PG parity (fix)
- **#68** `searchByEmbedding` Local API method (feat)
- **#70** `populateEmbedding` on `search()` / `searchByEmbedding()` + `embedding` typed on `VectorSearchResult` / `EmbeddingRecord` (feat)

(#61 cf workers-types refactor and #67/#69 docs are internal/non-user-facing and intentionally omitted from the changeset — say the word if you want #61 noted.)

## Config change

`.changeset/config.json` gains `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true`. Without it, the four-package `fixed` group's peer-dependency cascade turns this `minor` into a `2.0.0` major. With it, `changeset status` resolves to `1.1.0` (verified).

No code changes — changeset + config only.